### PR TITLE
feat: Custom search results (color picker + font & font weight selection)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@quenty/rx": "^13.16.0",
     "@quenty/servicebag": "^11.11.0",
     "@quenty/signal": "^7.10.0",
+    "@quenty/string": "^3.3.0",
     "@quenty/valueobject": "^13.16.0"
   },
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@quenty/brio": "^14.16.0",
     "@quenty/buttonhighlightmodel": "^14.17.0",
     "@quenty/fzy": "^5.8.0",
+    "@quenty/lipsum": "^14.17.0",
     "@quenty/loader": "^10.8.0",
     "@quenty/observablecollection": "^12.19.0",
     "@quenty/rx": "^13.16.0",

--- a/src/StudioMacros/init.server.lua
+++ b/src/StudioMacros/init.server.lua
@@ -144,7 +144,9 @@ local function initialize(plugin)
 						return
 					end
 
-					activeMacro = nil
+					if not leavePaneOpen then
+						activeMacro = nil
+					end
 
 					local newSelection = {}
 					local selectedInstances = Selection:Get()

--- a/src/StudioMacros/init.server.lua
+++ b/src/StudioMacros/init.server.lua
@@ -38,6 +38,10 @@ local function initialize(plugin)
 	)
 
 	maid:GiveTask(toggleCommand.Triggered:Connect(function()
+		if pane:IsVisible() then
+			pane:CaptureFocus()
+		end
+
 		pane.TargetSelection.Value = Selection:Get()
 		pane:Show()
 	end))
@@ -172,6 +176,7 @@ local function initialize(plugin)
 					end
 
 					if #selectedInstances > 0 then
+						startRecording()
 						for _, selectedInstance in selectedInstances do
 							if macroData.Predicate then
 								local validInstance = macroData.Predicate(selectedInstance)
@@ -181,7 +186,6 @@ local function initialize(plugin)
 								end
 							end
 
-							startRecording()
 							local newInstance = macroData.Macro(selectedInstance, plugin, ...)
 
 							if not leavePaneOpen then

--- a/src/StudioMacros/init.server.lua
+++ b/src/StudioMacros/init.server.lua
@@ -64,6 +64,11 @@ local function initialize(plugin)
 				groupEntry:SetIsCollapsed(true)
 			end
 
+			local activeMacro, leaveActiveMacroOpen
+			maid:GiveTask(pane.CustomResultsReset:Connect(function()
+				activeMacro = nil
+			end))
+
 			for macroIndex, macro in group:GetChildren() do
 				if macro.Name == "GroupData" or not macro:IsA("ModuleScript") then
 					continue
@@ -120,7 +125,6 @@ local function initialize(plugin)
 						end))
 				end
 
-				local activeMacro, leaveActiveMacroOpen
 				local function activated(leavePaneOpen: boolean?, ...)
 					if macroEntry:IsGroupHeader() then
 						return

--- a/src/StudioMacros/macros/Color/ChangeBackgroundColor.luau
+++ b/src/StudioMacros/macros/Color/ChangeBackgroundColor.luau
@@ -1,0 +1,20 @@
+return {
+	Name = "Change Background Color";
+	Description = "Change the BackgroundColor3 of a GuiObject.";
+	CustomResults = "Color";
+	TargetProperty = "BackgroundColor3";
+
+	Predicate = function(gui)
+		return gui:IsA("GuiObject")
+	end;
+
+	Macro = function(gui, _, color)
+		if not color then
+			return
+		end
+
+		if typeof(color) == "Color3" then
+			gui.BackgroundColor3 = color
+		end
+	end;
+}

--- a/src/StudioMacros/macros/Color/ChangeStrokeColor.luau
+++ b/src/StudioMacros/macros/Color/ChangeStrokeColor.luau
@@ -1,0 +1,20 @@
+return {
+	Name = "Change Stroke Color";
+	Description = "Change the color of a UIStroke.";
+	CustomResults = "Color";
+	TargetProperty = "Color";
+
+	Predicate = function(gui)
+		return gui:IsA("UIStroke")
+	end;
+
+	Macro = function(gui, _, color)
+		if not color then
+			return
+		end
+
+		if typeof(color) == "Color3" then
+			gui.Color = color
+		end
+	end;
+}

--- a/src/StudioMacros/macros/Color/ChangeTextColor.luau
+++ b/src/StudioMacros/macros/Color/ChangeTextColor.luau
@@ -1,0 +1,22 @@
+return {
+	Name = "Change Text Color";
+	Description = "Change the TextColor3 of a GuiObject.";
+	CustomResults = "Color";
+	TargetProperty = "TextColor3";
+
+	Predicate = function(gui)
+		return gui:IsA("TextLabel")
+			or gui:IsA("TextButton")
+			or gui:IsA("TextBox")
+	end;
+
+	Macro = function(gui, _, color)
+		if not color then
+			return
+		end
+
+		if typeof(color) == "Color3" then
+			gui.TextColor3 = color
+		end
+	end;
+}

--- a/src/StudioMacros/macros/Color/ToggleColor.luau
+++ b/src/StudioMacros/macros/Color/ToggleColor.luau
@@ -1,14 +1,20 @@
 return {
 	Name = "Toggle Color";
-	Description = "Toggle the object's color (BackgroundColor3 or TextColor3) between black and white.";
+	Description = "Toggle the object's color between black and white.";
 
 	Predicate = function(gui)
-		return gui:IsA("Frame") or gui:IsA("TextLabel") or gui:IsA("TextButton") or gui:IsA("TextBox")
+		return gui:IsA("Frame")
+			or gui:IsA("TextLabel")
+			or gui:IsA("TextButton")
+			or gui:IsA("TextBox")
+			or gui:IsA("UIStroke")
 	end;
 
 	Macro = function(gui)
 		if gui:IsA("TextLabel") or gui:IsA("TextButton") or gui:IsA("TextBox") then
 			gui.TextColor3 = gui.TextColor3 == Color3.new(1, 1, 1) and Color3.new(0, 0, 0) or Color3.new(1, 1, 1)
+		elseif gui:IsA("UIStroke") then
+			gui.Color = gui.Color == Color3.new(1, 1, 1) and Color3.new(0, 0, 0) or Color3.new(1, 1, 1)
 		else
 			gui.BackgroundColor3 = gui.BackgroundColor3 == Color3.new(1, 1, 1) and Color3.new(0, 0, 0) or Color3.new(1, 1, 1)
 		end

--- a/src/StudioMacros/macros/Layout/CyclePaddingOffset.luau
+++ b/src/StudioMacros/macros/Layout/CyclePaddingOffset.luau
@@ -1,6 +1,6 @@
 return {
 	Name = "Cycle Padding (5px, offset)";
-	Description = "Cycle the UIPadding offset by 5px (5px, 10px, 15px).";
+	Description = "Toggle the UIPadding offset by 5px (5px, 10px, 15px).";
 
 	Predicate = function(gui)
 		return gui:IsA("UIPadding")

--- a/src/StudioMacros/macros/Layout/CyclePaddingScale.luau
+++ b/src/StudioMacros/macros/Layout/CyclePaddingScale.luau
@@ -1,6 +1,6 @@
 return {
 	Name = "Cycle Padding (5px, scale)";
-	Description = "Cycle the UIPadding scale by 5px (5px, 10px, 15px).";
+	Description = "Toggle the UIPadding scale by 5px (5px, 10px, 15px).";
 
 	Predicate = function(gui)
 		return gui:IsA("UIPadding")

--- a/src/StudioMacros/macros/Layout/DecrementLayoutOrder.luau
+++ b/src/StudioMacros/macros/Layout/DecrementLayoutOrder.luau
@@ -1,6 +1,6 @@
 return {
 	Name = "Decrement Layout Order";
-	Description = "Decrement the object's layout order.";
+	Description = "Decrement the object's LayoutOrder.";
 
 	Predicate = function(gui)
 		return gui:IsA("GuiObject")

--- a/src/StudioMacros/macros/Layout/IncrementLayoutOrder.luau
+++ b/src/StudioMacros/macros/Layout/IncrementLayoutOrder.luau
@@ -1,6 +1,6 @@
 return {
 	Name = "Increment Layout Order";
-	Description = "Increment the object's layout order.";
+	Description = "Increment the object's LayoutOrder.";
 
 	Predicate = function(gui)
 		return gui:IsA("GuiObject")

--- a/src/StudioMacros/macros/Text/ChangeFont.luau
+++ b/src/StudioMacros/macros/Text/ChangeFont.luau
@@ -1,0 +1,19 @@
+return {
+	Name = "Change Font";
+	Description = "Change the font on a text object.";
+	CustomResults = "Font";
+
+	Predicate = function(gui)
+		return gui:IsA("TextLabel")
+			or gui:IsA("TextButton")
+			or gui:IsA("TextBox")
+	end;
+
+	Macro = function(gui, _, font)
+		if not font then
+			return
+		end
+
+		gui.FontFace = font
+	end;
+}

--- a/src/StudioMacros/macros/Text/ChangeFontStyle.luau
+++ b/src/StudioMacros/macros/Text/ChangeFontStyle.luau
@@ -1,0 +1,22 @@
+return {
+	Name = "Change Font Style";
+	Description = "Change the font style, including font weight for bold and italic text.";
+	CustomResults = "FontStyle";
+
+	Predicate = function(gui)
+		return gui:IsA("TextLabel")
+			or gui:IsA("TextButton")
+			or gui:IsA("TextBox")
+	end;
+
+	Macro = function(gui, _, fontWeight, isItalic)
+		if not fontWeight then
+			return
+		end
+
+		local currentFontFace = gui.FontFace
+		local fontStyle = isItalic and Enum.FontStyle.Italic or Enum.FontStyle.Normal
+
+		gui.FontFace = Font.new(currentFontFace.Family, fontWeight, fontStyle)
+	end;
+}

--- a/src/StudioMacros/modules/Shared/CommandPalette/CommandEntry.luau
+++ b/src/StudioMacros/modules/Shared/CommandPalette/CommandEntry.luau
@@ -5,6 +5,7 @@ local Blend = require("Blend")
 local ButtonHighlightModel = require("ButtonHighlightModel")
 local Fzy = require("Fzy")
 local Rx = require("Rx")
+local SearchUtils = require("SearchUtils")
 local Signal = require("Signal")
 local ValueObject = require("ValueObject")
 
@@ -73,55 +74,6 @@ function CommandEntry:SetDefaultIndex(index: number)
 	self._defaultIndex.Value = index
 end
 
-function CommandEntry:_getMatchedString(fzyConfig, targetString, searchQuery)
-	if not fzyConfig or not targetString or not searchQuery then
-		return
-	end
-
-	searchQuery = string.lower(searchQuery)
-
-	local positions = Fzy.positions(fzyConfig, searchQuery, string.lower(targetString))
-	if not positions or #positions == 0 then
-		return targetString
-	end
-
-	local ranges = {}
-	local startPos, endPos = positions[1], positions[1]
-
-	for i = 2, #positions do
-		if positions[i] == endPos + 1 then
-			endPos = positions[i]
-
-			if i == #positions then
-				table.insert(ranges, { startPos, endPos })
-			end
-		else
-			table.insert(ranges, { startPos, endPos })
-			startPos = positions[i]
-			endPos = positions[i]
-		end
-	end
-
-	if #ranges == 0 then
-		return targetString
-	end
-
-	local finalString = ""
-
-	for index, range in ranges do
-		local start = string.sub(targetString, index == 1 and 0 or ranges[index - 1][2] + 1, range[1] - 1)
-		local matched = string.sub(targetString, range[1], range[2])
-
-		finalString ..= `{start}<font color="#d0a4f7">{matched}</font>`
-
-		if index == #ranges then
-			finalString ..= string.sub(targetString, range[2] + 1, string.len(targetString))
-		end
-	end
-
-	return finalString
-end
-
 function CommandEntry:SetIsSelected(isSelected: boolean)
 	self._model:SetIsChoosen(isSelected)
 	self._model._isMouseOver.Value = isSelected
@@ -187,7 +139,11 @@ function CommandEntry:Render(props)
 			return UDim2.new(1, 0, 0, height)
 		end);
 
-		Visible = Blend.Computed(self._isGroupHeader, groupCollapsed, props.SearchQuery, self.SearchScore, function(isGroupEntry, isCollapsed, searchQuery, searchScore)
+		Visible = Blend.Computed(self._isGroupHeader, groupCollapsed, props.SearchQuery, self.SearchScore, props.CustomResult, props.Enabled, function(isGroupEntry, isCollapsed, searchQuery, searchScore, customResult, isEnabled)
+			if customResult then
+				return isEnabled
+			end
+
 			if isGroupEntry then
 				return searchQuery == ""
 			else
@@ -360,7 +316,7 @@ function CommandEntry:Render(props)
 
 					Text = Blend.Computed(self._macroName, props.SearchQuery, function(macroName, searchQuery)
 						if searchQuery ~= "" then
-							return self:_getMatchedString(fzyConfig, macroName, searchQuery)
+							return SearchUtils.getMatchedString(fzyConfig, macroName, searchQuery)
 						else
 							return macroName
 						end
@@ -385,7 +341,7 @@ function CommandEntry:Render(props)
 
 					Text = Blend.Computed(self._macroDescription, props.SearchQuery, function(description, searchQuery)
 						if searchQuery ~= "" then
-							return self:_getMatchedString(fzyConfig, description, searchQuery)
+							return SearchUtils.getMatchedString(fzyConfig, description, searchQuery)
 						else
 							return description
 						end

--- a/src/StudioMacros/modules/Shared/CommandPalette/CommandGroup.luau
+++ b/src/StudioMacros/modules/Shared/CommandPalette/CommandGroup.luau
@@ -21,6 +21,7 @@ function CommandGroup.new()
 	self._percentVisibleTarget = self._maid:Add(ValueObject.new(0))
 
 	self.Activated = self._maid:Add(Signal.new())
+	self.LayoutOrder = self._maid:Add(ValueObject.new(0))
 
 	self._maid:GiveTask(self.VisibleChanged:Connect(function(isVisible)
 		self._percentVisibleTarget.Value = isVisible and 1 or 0
@@ -98,7 +99,7 @@ function CommandGroup:Render(props)
 
 	local targetParent = self._maid:Add(Blend.State(nil))
 
-	self._maid:GiveTask(props.TargetParent:Observe():Subscribe(function(target)
+	self._maid:GiveTask(props.TargetParent:Subscribe(function(target)
 		if target == nil then
 			targetParent.Value = self._groupFrame
 		else
@@ -110,10 +111,17 @@ function CommandGroup:Render(props)
 		Name = "CommandGroup";
 		AutomaticSize = Enum.AutomaticSize.Y;
 		BackgroundTransparency = 1;
+		LayoutOrder = self.LayoutOrder;
 		Size = UDim2.fromScale(1, 0);
 
-		Visible = Blend.Computed(props.TargetParent, function(target)
-			return target == nil
+		Visible = Blend.Computed(props.TargetParent, props.CustomResult, props.Enabled, function(target, customResult, isEnabled)
+			if customResult then
+				return isEnabled
+			elseif not target then
+				return true
+			end
+
+			return false
 		end);
 
 		Blend.New "UIListLayout" {
@@ -129,6 +137,8 @@ function CommandGroup:Render(props)
 		self._entries:ObserveItemsBrio():Pipe({
 			RxBrioUtils.map(function(entry)
 				return entry:Render({
+					CustomResult = props.CustomResult;
+					Enabled = props.Enabled;
 					EntryHeight = props.EntryHeight;
 					FzyConfig = props.FzyConfig;
 					GroupCollapsed = self._groupCollapsed;

--- a/src/StudioMacros/modules/Shared/CommandPalette/CommandPalette.luau
+++ b/src/StudioMacros/modules/Shared/CommandPalette/CommandPalette.luau
@@ -13,6 +13,7 @@ local ColorPickerPane = require("ColorPickerPane")
 local CommandGroup = require("CommandGroup")
 local FontData = require("FontData")
 local FontEntry = require("FontEntry")
+local FontStyleEntry = require("FontStyleEntry")
 local Fzy = require("Fzy")
 local LipsumUtils = require("LipsumUtils")
 local ObservableList = require("ObservableList")
@@ -55,6 +56,7 @@ function CommandPalette.new()
 	self._selectedGroupEntryIndex = self._maid:Add(ValueObject.new(0))
 	self._tabbed = self._maid:Add(Signal.new())
 	self._targetEntryParent = self._maid:Add(ValueObject.new(nil))
+	self._targetFont = self._maid:Add(ValueObject.new(nil))
 
 	self.CustomResultActivated = self._maid:Add(Signal.new())
 	self.TargetProperty = self._maid:Add(ValueObject.new(nil))
@@ -145,6 +147,7 @@ function CommandPalette:SetCustomResults(customResults: string)
 		self._entriesOffset.Value = 0
 		self._fontPreviewText.Value = ""
 		self._primaryIcon.Value = "rbxassetid://6031154871"
+		self._targetFont.Value = false
 		self._primaryModel:SetIsChoosen(false)
 
 		if self._lastSelectedEntryIndex then
@@ -181,7 +184,7 @@ function CommandPalette:SetCustomResults(customResults: string)
 
 		self._actionText.Value = "type any color (rgb, hex, color name)..."
 	elseif customResults == "Font" then
-		if not self._fontEntries then
+		if not self._fontEntries or not self._fontStyleEntries then
 			self:_setupFontResults()
 		end
 
@@ -191,8 +194,10 @@ function CommandPalette:SetCustomResults(customResults: string)
 			local instance = selection[1]
 			local text = ""
 
-			if instance:IsA("TextLabel") or instance:IsA("TextButton") or instance:IsA("TextBox") then
-				text = instance.Text
+			if instance then
+				if instance:IsA("TextLabel") or instance:IsA("TextButton") or instance:IsA("TextBox") then
+					text = instance.Text
+				end
 			end
 
 			if text == "" then
@@ -200,6 +205,22 @@ function CommandPalette:SetCustomResults(customResults: string)
 			end
 
 			self._fontPreviewText.Value = string.sub(text, 0, 90)
+		end
+	elseif customResults == "FontStyle" then
+		if not self._fontEntries or not self._fontStyleEntries then
+			self:_setupFontResults()
+		end
+
+		self._actionText.Value = "type any font style..."
+
+		if selection then
+			local instance = selection[1]
+
+			if instance then
+				if instance:IsA("TextLabel") or instance:IsA("TextButton") or instance:IsA("TextBox") then
+					self._targetFont.Value = instance.FontFace
+				end
+			end
 		end
 	end
 
@@ -332,9 +353,11 @@ function CommandPalette:_handleInput()
 			else
 				local customResultType = self._currentCustomResults.Value
 				if customResultType == "Color" then
-					currentGroupEntries = #self._colorEntries
+					currentGroupEntries = #self._colorEntries - 1
 				elseif customResultType == "Font" then
-					currentGroupEntries = #self._fontEntries
+					currentGroupEntries = #self._fontEntries - 1
+				elseif customResultType == "FontStyle" then
+					currentGroupEntries = #self._fontStyleEntries - 1
 				end
 			end
 
@@ -407,6 +430,8 @@ function CommandPalette:_setupSearch()
 					currentEntries = self._colorEntries
 				elseif data.CustomResultType == "Font" then
 					currentEntries = self._fontEntries
+				elseif data.CustomResultType == "FontStyle" then
+					currentEntries = self._fontStyleEntries
 				end
 			end
 
@@ -571,7 +596,7 @@ function CommandPalette:_setupColorResults()
 			end
 
 			local score = scoreBrio:GetValue()
-			if score == nil or score == -math.huge then
+			if score == nil or score < 0 then
 				return
 			end
 
@@ -598,35 +623,67 @@ function CommandPalette:_setupFontResults()
 	end
 
 	self._fontEntries = {}
+	self._fontStyleEntries = {}
 
-	local sortedEntries = {}
+	local sortedFontEntries = {}
+	local sortedFontStyleEntries = {}
+	local styleEntryMap = {}
 
 	for fontId, data in FontData do
-		local entry = self._maid:Add(FontEntry.new())
-		entry:SetFontName(data.Name)
-		entry:SetStyleCount(#data.Styles)
-
+		local newFont
 		if typeof(fontId) == "number" then
-			entry.Font.Value = Font.fromId(fontId)
+			newFont = Font.fromId(fontId)
 		elseif typeof(fontId) == "string" then
-			entry.Font.Value = Font.new(fontId)
+			newFont = Font.new(fontId)
 		end
 
-		self._maid:GiveTask(entry.Activated:Connect(function(shiftPressed)
-			self.CustomResultActivated:Fire("Font", shiftPressed, entry.Font.Value)
+		local fontNameEntry = self._maid:Add(FontEntry.new())
+		fontNameEntry:SetFontName(data.Name)
+		fontNameEntry:SetStyleCount(#data.Styles)
+		fontNameEntry.Font.Value = newFont
+
+		for _, style in data.Styles do
+			local isItalic = string.find(style, "Italic") and true or false
+			local styleEntry = styleEntryMap[style]
+
+			if not styleEntry then
+				styleEntry = self._maid:Add(FontStyleEntry.new())
+				styleEntry:SetIsItalic(isItalic)
+				styleEntry:SetStyleName(style)
+
+				table.insert(sortedFontStyleEntries, styleEntry)
+				styleEntryMap[style] = styleEntry
+
+				self._maid:GiveTask(styleEntry.Activated:Connect(function(shiftPressed)
+					self.CustomResultActivated:Fire("FontStyle", shiftPressed, styleEntry:GetData())
+				end))
+			end
+
+			styleEntry:SetFontCompatible(newFont)
+		end
+
+		self._maid:GiveTask(fontNameEntry.Activated:Connect(function(shiftPressed)
+			self.CustomResultActivated:Fire("Font", shiftPressed, fontNameEntry.Font.Value)
 		end))
 
-		table.insert(sortedEntries, entry)
+		table.insert(sortedFontEntries, fontNameEntry)
 	end
 
-	table.sort(sortedEntries, function(a, b)
+	table.sort(sortedFontEntries, function(a, b)
 		local aFontName = a:GetFontName()
 		local bFontName = b:GetFontName()
 
 		return aFontName < bFontName
 	end)
 
-	for index, entry in sortedEntries do
+	table.sort(sortedFontStyleEntries, function(a, b)
+		local aFontWeight = a:GetFontWeight()
+		local bFontWeight = b:GetFontWeight()
+
+		return aFontWeight < bFontWeight
+	end)
+
+	for index, entry in sortedFontEntries do
 		entry:SetDefaultIndex(index)
 		table.insert(self._fontEntries, entry)
 		self._maid:GiveTask(self._entries:Add(entry))
@@ -643,7 +700,37 @@ function CommandPalette:_setupFontResults()
 			end
 
 			local score = scoreBrio:GetValue()
-			if score == nil or score == -math.huge then
+			if score == nil or score < 0 then
+				return
+			end
+
+			scoreBrio:ToMaid():GiveTask(self._searchEntries:Add(entry, entry.SearchScore:Observe()))
+		end))
+	end
+
+	for index, entry in sortedFontStyleEntries do
+		entry:SetDefaultIndex(index)
+		table.insert(self._fontStyleEntries, entry)
+		self._maid:GiveTask(self._entries:Add(entry))
+
+		self._maid:GiveTask(entry.SearchScore:ObserveBrio():Subscribe(function(scoreBrio)
+			if scoreBrio:IsDead() then
+				return
+			end
+
+			if not self._customResultsEnabled.Value then
+				return
+			elseif entry.CustomResultType ~= self._currentCustomResults.Value then
+				return
+			end
+
+			local targetFont = self._targetFont.Value
+			if not targetFont or not entry:IsFontCompatible(targetFont) then
+				return
+			end
+
+			local score = scoreBrio:GetValue()
+			if score == nil or score < 0 then
 				return
 			end
 
@@ -653,12 +740,18 @@ function CommandPalette:_setupFontResults()
 
 	self._maid:GiveTask(Blend.Computed(self._customResultsEnabled, self._currentCustomResults, function(isEnabled, resultsType)
 		local isVisible = false
-		if isEnabled and resultsType == "Font" then
+		if isEnabled then
 			isVisible = true
 		end
 
-		for _, entry in self._fontEntries do
-			entry:SetVisible(isVisible)
+		if resultsType == "Font" then
+			for _, entry in self._fontEntries do
+				entry:SetVisible(isVisible)
+			end
+		elseif resultsType == "FontStyle" then
+			for _, entry in self._fontStyleEntries do
+				entry:SetVisible(isVisible)
+			end
 		end
 	end):Subscribe())
 end
@@ -727,6 +820,11 @@ function CommandPalette:Render(props)
 
 			local entryPosition = entry:GetYPosition() - framePosition
 			local entrySize = self._entryHeight.Value
+
+			local customResults = self._currentCustomResults.Value
+			if customResults == "Font" or customResults == "FontStyle" then
+				entrySize = entrySize == 45 and 60 or 40
+			end
 
 			local entryBottom = entryPosition + entrySize
 			local newCanvasPosition = canvasPosition
@@ -1231,6 +1329,7 @@ function CommandPalette:Render(props)
 									SearchQuery = self._searchQuery;
 									Tabbed = self._tabbed;
 									Transparency = transparency;
+									TargetFont = self._targetFont;
 
 									Enabled = Blend.Computed(self._customResultsEnabled, self._currentCustomResults, function(isEnabled, customResults)
 										if customResults and groupEntry.CustomResultType == customResults then

--- a/src/StudioMacros/modules/Shared/CommandPalette/CommandPalette.luau
+++ b/src/StudioMacros/modules/Shared/CommandPalette/CommandPalette.luau
@@ -1,5 +1,6 @@
 local require = require(script.Parent.loader).load(script)
 
+local ChangeHistoryService = game:GetService("ChangeHistoryService")
 local RunService = game:GetService("RunService")
 local TweenService = game:GetService("TweenService")
 local UserInputService = game:GetService("UserInputService")
@@ -39,6 +40,7 @@ function CommandPalette.new()
 	self._currentCustomResults = self._maid:Add(ValueObject.new(nil))
 	self._customResultsEnabled = self._maid:Add(ValueObject.new(false))
 	self._entries = self._maid:Add(ObservableList.new())
+	self._entriesOffset = self._maid:Add(ValueObject.new(0))
 	self._entryHeight = self._maid:Add(ValueObject.new(45))
 	self._fontPreviewText = self._maid:Add(ValueObject.new(""))
 	self._inputFocused = self._maid:Add(ValueObject.new(false))
@@ -63,7 +65,7 @@ function CommandPalette.new()
 	self._maid:GiveTask(self.VisibleChanged:Connect(function(isVisible)
 		if self._input then
 			if isVisible then
-				self._input:CaptureFocus()
+				self:CaptureFocus()
 
 				if #self._entries:GetList() > 0 then
 					if self._searchQuery.Value ~= "" then
@@ -139,6 +141,7 @@ function CommandPalette:SetCustomResults(customResults: string)
 		self._actionText.Value = "select a command..."
 		self._currentCustomResults.Value = nil
 		self._customResultsEnabled.Value = false
+		self._entriesOffset.Value = 0
 		self._fontPreviewText.Value = ""
 		self._primaryIcon.Value = "rbxassetid://6031154871"
 		self._primaryModel:SetIsChoosen(false)
@@ -152,7 +155,7 @@ function CommandPalette:SetCustomResults(customResults: string)
 			task.defer(function()
 				RunService.RenderStepped:Wait()
 				self._input.Text = self._lastSearchQuery or ""
-				self._input:CaptureFocus()
+				self:CaptureFocus()
 			end)
 		end
 
@@ -166,10 +169,7 @@ function CommandPalette:SetCustomResults(customResults: string)
 	self._primaryIcon.Value = "rbxassetid://6031091000"
 	self._primaryModel:SetIsChoosen(true)
 
-	task.defer(function()
-		RunService.RenderStepped:Wait()
-		self._input:CaptureFocus()
-	end)
+	self:CaptureFocus()
 
 	local selection = self.TargetSelection.Value
 
@@ -211,6 +211,7 @@ function CommandPalette:_handleInput()
 	self._maid:GiveTask(UserInputService.InputBegan:Connect(function(input, gpe)
 		local keysPressed = UserInputService:GetKeysPressed()
 		local upPressed, downPressed, ctrlPressed = false, false, false
+		local shiftPressed = false
 
 		if input.KeyCode == Enum.KeyCode.Up then
 			upPressed = true
@@ -222,7 +223,8 @@ function CommandPalette:_handleInput()
 		for _, inputObject in keysPressed do
 			if inputObject.KeyCode == Enum.KeyCode.LeftControl or inputObject.KeyCode == Enum.KeyCode.RightControl then
 				ctrlPressed = true
-				break
+			elseif inputObject.KeyCode == Enum.KeyCode.LeftShift then
+				shiftPressed = true
 			end
 		end
 
@@ -246,22 +248,34 @@ function CommandPalette:_handleInput()
 		if input.KeyCode == Enum.KeyCode.Escape then
 			if self._customResultsEnabled.Value then
 				if self._input.Text == "" then
-					self._primaryModel:SetKeyDown(true)
-					self._maid:GiveTask(task.delay(0.1, function()
-						self._primaryModel:SetKeyDown(false)
-					end))
+					if shiftPressed then
+						self._input:ReleaseFocus()
+					else
+						self._primaryModel:SetKeyDown(true)
+						self._maid:GiveTask(task.delay(0.1, function()
+							self._primaryModel:SetKeyDown(false)
+						end))
 
-					self:SetCustomResults(nil)
+						self:SetCustomResults(nil)
+					end
 				else
-					self._input.Text = ""
-					self._input:CaptureFocus()
+					if shiftPressed then
+						self._input:ReleaseFocus()
+					else
+						self._input.Text = ""
+						self:CaptureFocus()
+					end
 				end
 			else
-				if self._input.Text == "" then
-					self:Hide()
+				if shiftPressed then
+					self._input:ReleaseFocus()
 				else
-					self._input.Text = ""
-					self._input:CaptureFocus()
+					if self._input.Text == "" then
+						self:Hide()
+					else
+						self._input.Text = ""
+						self:CaptureFocus()
+					end
 				end
 			end
 		elseif upPressed or downPressed then
@@ -419,6 +433,11 @@ function CommandPalette:_setupColorResults()
 	local sortedEntries = {}
 	local colorPickerPane = self._maid:Add(ColorPickerPane.new())
 
+	self._colorPicker = colorPickerPane
+	if self._bodyFrame then
+		self._colorPicker:SetTargetParent(self._bodyFrame)
+	end
+
 	self._maid:GiveTask(self._currentCustomResults:ObserveBrio():Subscribe(function(customResultsBrio)
 		if customResultsBrio:IsDead() then
 			return
@@ -434,12 +453,37 @@ function CommandPalette:_setupColorResults()
 			return
 		end
 
-		local instance = initialSelection[1]
 		local targetProperty = self.TargetProperty.Value
-
-		if targetProperty and instance:IsA("GuiObject") then
-			maid:GiveTask(colorPickerPane:SetColor(RxInstanceUtils.observeProperty(instance, targetProperty)))
+		if not targetProperty then
+			return
 		end
+
+		colorPickerPane:SetColor(initialSelection[1][targetProperty])
+
+		-- Undo/redo support
+		maid:GiveTask(ChangeHistoryService.OnUndo:Connect(function()
+			colorPickerPane:SetColor(initialSelection[1][targetProperty])
+		end))
+
+		maid:GiveTask(ChangeHistoryService.OnRedo:Connect(function()
+			colorPickerPane:SetColor(initialSelection[1][targetProperty])
+		end))
+
+		maid:GiveTask(colorPickerPane:ObserveColor():Subscribe(function(newColor)
+			if not newColor or initialSelection[1][targetProperty] == newColor then
+				return
+			end
+
+			for _, instance in initialSelection do
+				instance[targetProperty] = newColor
+			end
+		end))
+
+		-- Since we don't want to spam the undo stack as they're picking a
+		-- color, we only want to fire the macro when the user stops dragging
+		maid:GiveTask(colorPickerPane.ColorUpdated:Connect(function(newColor)
+			self.CustomResultActivated:Fire("Color", true, newColor)
+		end))
 	end))
 
 	local function createColorEntry(i)
@@ -455,6 +499,7 @@ function CommandPalette:_setupColorResults()
 		table.insert(sortedEntries, entry)
 
 		self._maid:GiveTask(entry.Activated:Connect(function(shiftPressed)
+			colorPickerPane:SetColor(brickColor.Color)
 			self.CustomResultActivated:Fire("Color", shiftPressed, brickColor.Color)
 		end))
 	end
@@ -596,6 +641,17 @@ function CommandPalette:_setupFontResults()
 	end):Subscribe())
 end
 
+function CommandPalette:CaptureFocus()
+	if not self._input then
+		return
+	end
+
+	task.defer(function()
+		RunService.RenderStepped:Wait()
+		self._input:CaptureFocus()
+	end)
+end
+
 function CommandPalette:Render(props)
 	local target = self._percentVisibleTarget:Observe()
 
@@ -649,11 +705,6 @@ function CommandPalette:Render(props)
 
 			local entryPosition = entry:GetYPosition() - framePosition
 			local entrySize = self._entryHeight.Value
-
-			-- Account for color picker at the top of the list
-			if self._currentCustomResults.Value == "Color" then
-				entryPosition += 160
-			end
 
 			local entryBottom = entryPosition + entrySize
 			local newCanvasPosition = canvasPosition
@@ -916,17 +967,18 @@ function CommandPalette:Render(props)
 							[Blend.OnEvent "FocusLost"] = function(enterPressed)
 								local selectedEntry = self._selectedEntry.Value
 								local refocusInput = false
-								local shiftPressed = false
+								local escapePressed, shiftPressed = false
 
 								-- Hold shift to trigger without closing the palette
 								for _, inputObject in UserInputService:GetKeysPressed() do
 									if inputObject.KeyCode == Enum.KeyCode.LeftShift then
 										shiftPressed = true
-										break
+									elseif inputObject.KeyCode == Enum.KeyCode.Escape then
+										escapePressed = true
 									end
 								end
 
-								if shiftPressed then
+								if shiftPressed and not escapePressed then
 									refocusInput = true
 								end
 
@@ -942,12 +994,7 @@ function CommandPalette:Render(props)
 										groupEntry:SetIsCollapsed(not groupEntry:IsCollapsed())
 										refocusInput = true
 									else
-										if selectedEntry.CustomResultType then
-											local customResultsType = self._currentCustomResults.Value
-											self.CustomResultActivated:Fire(customResultsType, shiftPressed, selectedEntry:GetData())
-										else
-											selectedEntry.Activated:Fire(shiftPressed)
-										end
+										selectedEntry.Activated:Fire(shiftPressed)
 									end
 								elseif enterPressed then
 									if self._customResultsEnabled.Value then
@@ -956,20 +1003,25 @@ function CommandPalette:Render(props)
 											local currentText = self._input.Text
 											if SearchUtils.stringIsRGB(currentText) then
 												local _, r, g, b = SearchUtils.stringIsRGB(currentText)
-												self.CustomResultActivated:Fire("Color", shiftPressed, Color3.fromRGB(r, g, b))
+												local newColor = Color3.fromRGB(r, g, b)
+												if self._colorPicker then
+													self._colorPicker:SetColor(newColor)
+												end
+												self.CustomResultActivated:Fire("Color", shiftPressed, newColor)
 											elseif SearchUtils.stringIsHex(currentText) then
 												local _, hex = SearchUtils.stringIsHex(currentText)
-												self.CustomResultActivated:Fire("Color", shiftPressed, Color3.fromHex(hex))
+												local newColor = Color3.fromHex(hex)
+												if self._colorPicker then
+													self._colorPicker:SetColor(newColor)
+												end
+												self.CustomResultActivated:Fire("Color", shiftPressed, newColor)
 											end
 										end
 									end
 								end
 
 								if refocusInput then
-									task.defer(function()
-										RunService.RenderStepped:Wait()
-										self._input:CaptureFocus()
-									end)
+									self:CaptureFocus()
 								else
 									self._inputFocused.Value = false
 								end
@@ -1066,7 +1118,7 @@ function CommandPalette:Render(props)
 						end);
 
 						[Blend.OnEvent "Activated"] = function()
-							self._input:CaptureFocus()
+							self:CaptureFocus()
 						end;
 					};
 				};
@@ -1084,6 +1136,10 @@ function CommandPalette:Render(props)
 						PaddingTop = UDim.new(0, 5);
 					};
 
+					[Blend.Instance] = function(frame)
+						self._bodyFrame = frame
+					end;
+
 					Blend.New "ScrollingFrame" {
 						Name = "entries";
 						Active = true;
@@ -1092,12 +1148,19 @@ function CommandPalette:Render(props)
 						ScrollBarImageTransparency = transparency;
 						ScrollingDirection = Enum.ScrollingDirection.Y;
 						ScrollingEnabled = self:ObserveVisible();
-						Size = UDim2.fromScale(1, 1);
 						VerticalScrollBarInset = Enum.ScrollBarInset.Always;
 						Visible = buttonVisible;
 
-						CanvasSize = Blend.Computed(contentHeight, function(contentHeight)
-							return UDim2.fromOffset(0, contentHeight + 2);
+						CanvasSize = Blend.Computed(contentHeight, self._entriesOffset, function(contentHeight, offset)
+							return UDim2.fromOffset(0, contentHeight + 2 - offset);
+						end);
+
+						Position = Blend.Computed(self._entriesOffset, function(offset)
+							return UDim2.fromOffset(0, offset)
+						end);
+
+						Size = Blend.Computed(self._entriesOffset, function(offset)
+							return UDim2.new(1, 0, 1, -offset)
 						end);
 
 						ScrollBarThickness = Blend.Computed(percentScrollThickness, function(percent)
@@ -1126,7 +1189,7 @@ function CommandPalette:Render(props)
 									return
 								end
 
-								contentHeight.Value = math.round(size.Y)
+								contentHeight.Value = math.round(size.Y) + self._entriesOffset.Value
 							end;
 						};
 
@@ -1151,7 +1214,17 @@ function CommandPalette:Render(props)
 									TargetParent = Blend.Computed(self._targetEntryParent, self._customResultsEnabled, self._currentCustomResults, function(targetParent, isEnabled, customResultType)
 										if groupEntry.CustomResultType then
 											if isEnabled then
-												return customResultType == groupEntry.CustomResultType and self._entriesFrame or nil
+												if customResultType == groupEntry.CustomResultType then
+													if groupEntry.Pinned then
+														self._entriesOffset.Value = groupEntry.Height or 0
+														groupEntry:SetTargetParent(self._bodyFrame)
+														return self._bodyFrame
+													else
+														return self._entriesFrame
+													end
+												else
+													return nil
+												end
 											else
 												return nil
 											end

--- a/src/StudioMacros/modules/Shared/CommandPalette/CommandPalette.luau
+++ b/src/StudioMacros/modules/Shared/CommandPalette/CommandPalette.luau
@@ -453,7 +453,6 @@ function CommandPalette:_setupColorResults()
 	end
 
 	self._maid:GiveTask(colorPickerPane.TabReturned:Connect(function()
-		print("tab returned")
 		self:CaptureFocus()
 	end))
 
@@ -474,6 +473,10 @@ function CommandPalette:_setupColorResults()
 
 		local targetProperty = self.TargetProperty.Value
 		if not targetProperty then
+			return
+		end
+
+		if not initialSelection[1][targetProperty] then
 			return
 		end
 

--- a/src/StudioMacros/modules/Shared/CommandPalette/CommandPalette.luau
+++ b/src/StudioMacros/modules/Shared/CommandPalette/CommandPalette.luau
@@ -942,7 +942,12 @@ function CommandPalette:Render(props)
 										groupEntry:SetIsCollapsed(not groupEntry:IsCollapsed())
 										refocusInput = true
 									else
-										selectedEntry.Activated:Fire(shiftPressed)
+										if selectedEntry.CustomResultType then
+											local customResultsType = self._currentCustomResults.Value
+											self.CustomResultActivated:Fire(customResultsType, shiftPressed, selectedEntry:GetData())
+										else
+											selectedEntry.Activated:Fire(shiftPressed)
+										end
 									end
 								elseif enterPressed then
 									if self._customResultsEnabled.Value then

--- a/src/StudioMacros/modules/Shared/CommandPalette/CommandPalette.luau
+++ b/src/StudioMacros/modules/Shared/CommandPalette/CommandPalette.luau
@@ -59,6 +59,7 @@ function CommandPalette.new()
 	self._targetFont = self._maid:Add(ValueObject.new(nil))
 
 	self.CustomResultActivated = self._maid:Add(Signal.new())
+	self.CustomResultsReset = self._maid:Add(Signal.new())
 	self.TargetProperty = self._maid:Add(ValueObject.new(nil))
 	self.TargetSelection = self._maid:Add(ValueObject.new(nil))
 
@@ -162,6 +163,8 @@ function CommandPalette:SetCustomResults(customResults: string)
 				self:CaptureFocus()
 			end)
 		end
+
+		self.CustomResultsReset:Fire()
 
 		return
 	end

--- a/src/StudioMacros/modules/Shared/CommandPalette/CommandPalette.luau
+++ b/src/StudioMacros/modules/Shared/CommandPalette/CommandPalette.luau
@@ -7,12 +7,20 @@ local UserInputService = game:GetService("UserInputService")
 local BasicPane = require("BasicPane")
 local Blend = require("Blend")
 local ButtonHighlightModel = require("ButtonHighlightModel")
+local ColorEntry = require("ColorEntry")
+local ColorPickerPane = require("ColorPickerPane")
 local CommandGroup = require("CommandGroup")
+local FontData = require("FontData")
+local FontEntry = require("FontEntry")
 local Fzy = require("Fzy")
+local LipsumUtils = require("LipsumUtils")
 local ObservableList = require("ObservableList")
 local ObservableSortedList = require("ObservableSortedList")
 local Rx = require("Rx")
 local RxBrioUtils = require("RxBrioUtils")
+local RxInstanceUtils = require("RxInstanceUtils")
+local SearchUtils = require("SearchUtils")
+local Signal = require("Signal")
 local ValueObject = require("ValueObject")
 
 local FZY_CONFIG = Fzy.createConfig()
@@ -25,18 +33,28 @@ CommandPalette.__index = CommandPalette
 function CommandPalette.new()
 	local self = setmetatable(BasicPane.new(), CommandPalette)
 
-	self._detailsModel = self._maid:Add(ButtonHighlightModel.new())
+	self._groupMap = {}
+
+	self._actionText = self._maid:Add(ValueObject.new("select a command..."))
+	self._currentCustomResults = self._maid:Add(ValueObject.new(nil))
+	self._customResultsEnabled = self._maid:Add(ValueObject.new(false))
 	self._entries = self._maid:Add(ObservableList.new())
 	self._entryHeight = self._maid:Add(ValueObject.new(45))
+	self._fontPreviewText = self._maid:Add(ValueObject.new(""))
 	self._inputFocused = self._maid:Add(ValueObject.new(false))
 	self._percentVisibleTarget = self._maid:Add(ValueObject.new(0))
+	self._primaryIcon = self._maid:Add(ValueObject.new("rbxassetid://6031154871"))
+	self._primaryModel = self._maid:Add(ButtonHighlightModel.new())
 	self._searchEntries = self._maid:Add(ObservableSortedList.new(true))
 	self._searchQuery = self._maid:Add(ValueObject.new(""))
+	self._secondaryModel = self._maid:Add(ButtonHighlightModel.new())
 	self._selectedEntry = self._maid:Add(ValueObject.new(nil))
 	self._selectedEntryIndex = self._maid:Add(ValueObject.new(0))
 	self._selectedGroupEntryIndex = self._maid:Add(ValueObject.new(0))
 	self._targetEntryParent = self._maid:Add(ValueObject.new(nil))
 
+	self.CustomResultActivated = self._maid:Add(Signal.new())
+	self.TargetProperty = self._maid:Add(ValueObject.new(nil))
 	self.TargetSelection = self._maid:Add(ValueObject.new(nil))
 
 	self:_handleInput()
@@ -59,10 +77,12 @@ function CommandPalette.new()
 			else
 				self._input.Text = ""
 				self.TargetSelection.Value = nil
+				self:SetCustomResults(nil)
 			end
 		end
 
-		self._detailsModel:SetInteractionEnabled(isVisible)
+		self._primaryModel:SetInteractionEnabled(isVisible)
+		self._secondaryModel:SetInteractionEnabled(isVisible)
 		self._percentVisibleTarget.Value = isVisible and 1 or 0
 	end))
 
@@ -76,6 +96,8 @@ function CommandPalette:AddGroup(groupData)
 
 	local groupEntry = self._maid:Add(CommandGroup.new())
 	groupEntry:SetHeader(groupData.Name, groupData.Icon)
+
+	table.insert(self._groupMap, groupEntry)
 
 	self._maid:GiveTask(self._entries:Add(groupEntry))
 	self._maid:GiveTask(groupEntry._entries:ObserveItemsBrio():Subscribe(function(entryBrio)
@@ -96,8 +118,12 @@ function CommandPalette:AddGroup(groupData)
 				return
 			end
 
+			if self._customResultsEnabled.Value and not entry.CustomResultType then
+				return
+			end
+
 			local score = scoreBrio:GetValue()
-			if score == nil or score == -math.huge then
+			if score == nil or score < 0 then
 				return
 			end
 
@@ -106,6 +132,79 @@ function CommandPalette:AddGroup(groupData)
 	end))
 
 	return groupEntry
+end
+
+function CommandPalette:SetCustomResults(customResults: string)
+	if not customResults then
+		self._actionText.Value = "select a command..."
+		self._currentCustomResults.Value = nil
+		self._customResultsEnabled.Value = false
+		self._fontPreviewText.Value = ""
+		self._primaryIcon.Value = "rbxassetid://6031154871"
+		self._primaryModel:SetIsChoosen(false)
+
+		if self._lastSelectedEntryIndex then
+			self._selectedEntryIndex.Value = self._lastSelectedEntryIndex
+			self._lastSelectedEntryIndex = nil
+		end
+
+		if self:IsVisible() then
+			task.defer(function()
+				RunService.RenderStepped:Wait()
+				self._input.Text = self._lastSearchQuery or ""
+				self._input:CaptureFocus()
+			end)
+		end
+
+		return
+	end
+
+	self._lastSelectedEntryIndex = self._selectedEntryIndex.Value
+	self._currentCustomResults.Value = customResults
+	self._customResultsEnabled.Value = true
+	self._input.Text = ""
+	self._primaryIcon.Value = "rbxassetid://6031091000"
+	self._primaryModel:SetIsChoosen(true)
+
+	task.defer(function()
+		RunService.RenderStepped:Wait()
+		self._input:CaptureFocus()
+	end)
+
+	local selection = self.TargetSelection.Value
+
+	if customResults == "Color" then
+		if not self._colorEntries then
+			self:_setupColorResults()
+		end
+
+		self._actionText.Value = "type any color (rgb, hex, color name)..."
+	elseif customResults == "Font" then
+		if not self._fontEntries then
+			self:_setupFontResults()
+		end
+
+		self._actionText.Value = "type any font name..."
+
+		if selection then
+			local instance = selection[1]
+			local text = ""
+
+			if instance:IsA("TextLabel") or instance:IsA("TextButton") or instance:IsA("TextBox") then
+				text = instance.Text
+			end
+
+			if text == "" then
+				text = LipsumUtils.sentence(7)
+			end
+
+			self._fontPreviewText.Value = string.sub(text, 0, 90)
+		end
+	end
+
+	task.defer(function()
+		self._selectedEntryIndex.Value = 0
+	end)
 end
 
 function CommandPalette:_handleInput()
@@ -135,21 +234,35 @@ function CommandPalette:_handleInput()
 					upPressed = true
 				elseif inputObject.KeyCode == Enum.KeyCode.D then
 					self._entryHeight.Value = self._entryHeight.Value == 45 and 30 or 45
-					self._detailsModel:SetKeyDown(true)
+					self._secondaryModel:SetKeyDown(true)
 
 					self._maid:GiveTask(task.delay(0.1, function()
-						self._detailsModel:SetKeyDown(false)
+						self._secondaryModel:SetKeyDown(false)
 					end))
 				end
 			end
 		end
 
 		if input.KeyCode == Enum.KeyCode.Escape then
-			if self._input.Text == "" then
-				self:Hide()
+			if self._customResultsEnabled.Value then
+				if self._input.Text == "" then
+					self._primaryModel:SetKeyDown(true)
+					self._maid:GiveTask(task.delay(0.1, function()
+						self._primaryModel:SetKeyDown(false)
+					end))
+
+					self:SetCustomResults(nil)
+				else
+					self._input.Text = ""
+					self._input:CaptureFocus()
+				end
 			else
-				self._input.Text = ""
-				self._input:CaptureFocus()
+				if self._input.Text == "" then
+					self:Hide()
+				else
+					self._input.Text = ""
+					self._input:CaptureFocus()
+				end
 			end
 		elseif upPressed or downPressed then
 			if self._searchQuery.Value ~= "" then
@@ -165,11 +278,13 @@ function CommandPalette:_handleInput()
 				return
 			end
 
+			local customResultsEnabled = self._customResultsEnabled.Value
+
 			local selectedEntry = self._selectedEntryIndex.Value
 			local selectedGroup = self._selectedGroupEntryIndex.Value
-			local groupEntries = self._entries:GetList()
+			local groupEntries = self._groupMap
 
-			if selectedGroup == 0 and selectedEntry == 0 then
+			if not customResultsEnabled and selectedGroup == 0 and selectedEntry == 0 then
 				if upPressed then
 					-- self._selectedGroupEntryIndex.Value = #groupEntries
 				else
@@ -183,32 +298,54 @@ function CommandPalette:_handleInput()
 				return
 			end
 
-			local currentGroupEntries = #currentGroup:GetEntries() - 1
+			local currentGroupEntries
+			if not customResultsEnabled then
+				currentGroupEntries = #currentGroup:GetEntries() - 1
+			else
+				local customResultType = self._currentCustomResults.Value
+				if customResultType == "Color" then
+					currentGroupEntries = #self._colorEntries
+				elseif customResultType == "Font" then
+					currentGroupEntries = #self._fontEntries
+				end
+			end
 
 			if upPressed then
-				if selectedEntry - 1 >= 0 and not currentGroup:IsCollapsed() then
-					self._selectedEntryIndex.Value -= 1
-				elseif selectedEntry == 0 then
-					if selectedGroup - 1 <= 0 then
-						-- self._selectedGroupEntryIndex.Value = #groupEntries
-						return
-					else
-						self._selectedGroupEntryIndex.Value -= 1
-					end
+				if not customResultsEnabled then
+					if selectedEntry - 1 >= 0 and not currentGroup:IsCollapsed() then
+						self._selectedEntryIndex.Value -= 1
+					elseif selectedEntry == 0 then
+						if selectedGroup - 1 <= 0 then
+							-- self._selectedGroupEntryIndex.Value = #groupEntries
+							return
+						else
+							self._selectedGroupEntryIndex.Value -= 1
+						end
 
-					local newGroup = groupEntries[self._selectedGroupEntryIndex.Value]
-					if newGroup:IsCollapsed() then
-						self._selectedEntryIndex.Value = 0
-					else
-						self._selectedEntryIndex.Value = #newGroup:GetEntries() - 1
+						local newGroup = groupEntries[self._selectedGroupEntryIndex.Value]
+						if newGroup:IsCollapsed() then
+							self._selectedEntryIndex.Value = 0
+						else
+							self._selectedEntryIndex.Value = #newGroup:GetEntries() - 1
+						end
+					end
+				else
+					if selectedEntry - 1 >= 0 then
+						self._selectedEntryIndex.Value -= 1
 					end
 				end
 			else
-				if selectedEntry + 1 <= currentGroupEntries and not currentGroup:IsCollapsed() then
-					self._selectedEntryIndex.Value += 1
-				elseif ((selectedEntry + 1 > currentGroupEntries) or currentGroup:IsCollapsed()) and selectedGroup + 1 <= #groupEntries then
-					self._selectedEntryIndex.Value = 0
-					self._selectedGroupEntryIndex.Value += 1
+				if not customResultsEnabled then
+					if selectedEntry + 1 <= currentGroupEntries and not currentGroup:IsCollapsed() then
+						self._selectedEntryIndex.Value += 1
+					elseif ((selectedEntry + 1 > currentGroupEntries) or currentGroup:IsCollapsed()) and selectedGroup + 1 <= #groupEntries then
+						self._selectedEntryIndex.Value = 0
+						self._selectedGroupEntryIndex.Value += 1
+					end
+				else
+					if selectedEntry + 1 <= currentGroupEntries then
+						self._selectedEntryIndex.Value += 1
+					end
 				end
 			end
 		end
@@ -219,18 +356,35 @@ function CommandPalette:_setupSearch()
 	self._maid:GiveTask(Rx.combineLatest({
 		CurrentEntry = self._selectedEntryIndex:Observe();
 		CurrentGroup = self._selectedGroupEntryIndex:Observe();
+		CustomResultType = self._currentCustomResults:Observe();
+		CustomResultsEnabled = self._customResultsEnabled:Observe();
 		SearchQuery = self._searchQuery:Observe();
 	}):Subscribe(function(data)
 		if data.SearchQuery ~= "" then
 			self._selectedEntry.Value = self._searchEntries:GetList()[data.CurrentEntry]
 		else
-			if data.CurrentGroup == 0 then
-				return
+			local currentEntries
+
+			if not data.CustomResultsEnabled then
+				if data.CurrentGroup == 0 then
+					return
+				end
+
+				local groupEntries = self._entries:GetList()
+				local currentGroup = groupEntries[data.CurrentGroup]
+
+				currentEntries = currentGroup:GetEntries()
+			else
+				if data.CustomResultType == "Color" then
+					currentEntries = self._colorEntries
+				elseif data.CustomResultType == "Font" then
+					currentEntries = self._fontEntries
+				end
 			end
 
-			local groupEntries = self._entries:GetList()
-			local currentGroup = groupEntries[data.CurrentGroup]
-			local currentEntries = currentGroup:GetEntries()
+			if not currentEntries then
+				return
+			end
 
 			if data.CurrentEntry == 0 then
 				self._selectedEntry.Value = currentEntries[1]
@@ -253,6 +407,193 @@ function CommandPalette:_setupSearch()
 		entry:SetIsSelected(true)
 		self._previousEntry = entry
 	end))
+end
+
+function CommandPalette:_setupColorResults()
+	if self._colorEntries then
+		return
+	end
+
+	self._colorEntries = {}
+
+	local sortedEntries = {}
+	local colorPickerPane = self._maid:Add(ColorPickerPane.new())
+
+	self._maid:GiveTask(self._currentCustomResults:ObserveBrio():Subscribe(function(customResultsBrio)
+		if customResultsBrio:IsDead() then
+			return
+		end
+
+		local maid, customResults = customResultsBrio:ToMaidAndValue()
+		if customResults ~= "Color" then
+			return
+		end
+
+		local initialSelection = self.TargetSelection.Value
+		if not initialSelection or #initialSelection == 0 then
+			return
+		end
+
+		local instance = initialSelection[1]
+		local targetProperty = self.TargetProperty.Value
+
+		if targetProperty and instance:IsA("GuiObject") then
+			maid:GiveTask(colorPickerPane:SetColor(RxInstanceUtils.observeProperty(instance, targetProperty)))
+		end
+	end))
+
+	local function createColorEntry(i)
+		local brickColor = BrickColor.new(i)
+		if brickColor.Name == "Medium stone grey" and i ~= 194 then
+			return
+		end
+
+		local entry = self._maid:Add(ColorEntry.new())
+		entry:SetColorName(brickColor.Name)
+		entry:SetColor(brickColor.Color)
+
+		table.insert(sortedEntries, entry)
+
+		self._maid:GiveTask(entry.Activated:Connect(function(shiftPressed)
+			self.CustomResultActivated:Fire("Color", shiftPressed, brickColor.Color)
+		end))
+	end
+
+	-- from https://create.roblox.com/docs/reference/engine/datatypes/BrickColor
+	for i = 1, 50 do
+		createColorEntry(i)
+	end
+
+	for i = 100, 365 do
+		createColorEntry(i)
+	end
+
+	for i = 1001, 1032 do
+		createColorEntry(i)
+	end
+
+	table.sort(sortedEntries, function(a, b)
+		local aH, aS, aV = a.Color.Value:ToHSV()
+		local bH, bS, bV = b.Color.Value:ToHSV()
+
+		if aH ~= bH then
+			return aH < bH
+		elseif aS ~= bS then
+			return aS < bS
+		else
+			return aV < bV
+		end
+	end)
+
+	self._maid:GiveTask(self._entries:Add(colorPickerPane))
+
+	for index, entry in sortedEntries do
+		entry:SetDefaultIndex(index)
+		table.insert(self._colorEntries, entry)
+		self._maid:GiveTask(self._entries:Add(entry))
+
+		self._maid:GiveTask(entry.SearchScore:ObserveBrio():Subscribe(function(scoreBrio)
+			if scoreBrio:IsDead() then
+				return
+			end
+
+			if not self._customResultsEnabled.Value then
+				return
+			elseif entry.CustomResultType ~= self._currentCustomResults.Value then
+				return
+			end
+
+			local score = scoreBrio:GetValue()
+			if score == nil or score == -math.huge then
+				return
+			end
+
+			scoreBrio:ToMaid():GiveTask(self._searchEntries:Add(entry, entry.SearchScore:Observe()))
+		end))
+	end
+
+	self._maid:GiveTask(Blend.Computed(self._customResultsEnabled, self._currentCustomResults, function(isEnabled, resultsType)
+		local isVisible = false
+		if isEnabled and resultsType == "Color" then
+			isVisible = true
+		end
+
+		colorPickerPane:SetVisible(isVisible)
+		for _, entry in self._colorEntries do
+			entry:SetVisible(isVisible)
+		end
+	end):Subscribe())
+end
+
+function CommandPalette:_setupFontResults()
+	if self._fontEntries then
+		return
+	end
+
+	self._fontEntries = {}
+
+	local sortedEntries = {}
+
+	for fontId, data in FontData do
+		local entry = self._maid:Add(FontEntry.new())
+		entry:SetFontName(data.Name)
+		entry:SetStyleCount(#data.Styles)
+
+		if typeof(fontId) == "number" then
+			entry.Font.Value = Font.fromId(fontId)
+		elseif typeof(fontId) == "string" then
+			entry.Font.Value = Font.new(fontId)
+		end
+
+		self._maid:GiveTask(entry.Activated:Connect(function(shiftPressed)
+			self.CustomResultActivated:Fire("Font", shiftPressed, entry.Font.Value)
+		end))
+
+		table.insert(sortedEntries, entry)
+	end
+
+	table.sort(sortedEntries, function(a, b)
+		local aFontName = a:GetFontName()
+		local bFontName = b:GetFontName()
+
+		return aFontName < bFontName
+	end)
+
+	for index, entry in sortedEntries do
+		entry:SetDefaultIndex(index)
+		table.insert(self._fontEntries, entry)
+		self._maid:GiveTask(self._entries:Add(entry))
+
+		self._maid:GiveTask(entry.SearchScore:ObserveBrio():Subscribe(function(scoreBrio)
+			if scoreBrio:IsDead() then
+				return
+			end
+
+			if not self._customResultsEnabled.Value then
+				return
+			elseif entry.CustomResultType ~= self._currentCustomResults.Value then
+				return
+			end
+
+			local score = scoreBrio:GetValue()
+			if score == nil or score == -math.huge then
+				return
+			end
+
+			scoreBrio:ToMaid():GiveTask(self._searchEntries:Add(entry, entry.SearchScore:Observe()))
+		end))
+	end
+
+	self._maid:GiveTask(Blend.Computed(self._customResultsEnabled, self._currentCustomResults, function(isEnabled, resultsType)
+		local isVisible = false
+		if isEnabled and resultsType == "Font" then
+			isVisible = true
+		end
+
+		for _, entry in self._fontEntries do
+			entry:SetVisible(isVisible)
+		end
+	end):Subscribe())
 end
 
 function CommandPalette:Render(props)
@@ -308,15 +649,24 @@ function CommandPalette:Render(props)
 
 			local entryPosition = entry:GetYPosition() - framePosition
 			local entrySize = self._entryHeight.Value
-			local entryBottom = entryPosition + entrySize
 
-			if entryPosition < canvasPosition then
+			-- Account for color picker at the top of the list
+			if self._currentCustomResults.Value == "Color" then
+				entryPosition += 160
+			end
+
+			local entryBottom = entryPosition + entrySize
+			local newCanvasPosition = canvasPosition
+
+			if entryBottom > frameSize then
+				newCanvasPosition += entryBottom - frameSize + 1
+			elseif entryPosition < framePosition then
+				newCanvasPosition -= entryPosition
+			end
+
+			if newCanvasPosition ~= canvasPosition then
 				TweenService:Create(self._entriesFrame, TWEEN_INFO, {
-					CanvasPosition = Vector2.new(0, entryPosition)
-				}):Play()
-			elseif entryBottom > frameSize then
-				TweenService:Create(self._entriesFrame, TWEEN_INFO, {
-					CanvasPosition = Vector2.new(0, canvasPosition + (entryBottom - frameSize) + 1)
+					CanvasPosition = Vector2.new(0, newCanvasPosition)
 				}):Play()
 			end
 		end
@@ -326,8 +676,11 @@ function CommandPalette:Render(props)
 		return percent > 0.01
 	end)
 
-	local detailsPercentHighlighted = Blend.AccelTween(self._detailsModel:ObservePercentHighlightedTarget(), 400)
-	local detailsPercentPressed = Blend.Spring(self._detailsModel:ObservePercentPressedTarget(), 40, 0.8)
+	local primaryPercentHighlighted = Blend.AccelTween(self._primaryModel:ObservePercentHighlightedTarget(), 400)
+	local primaryPercentPressed = Blend.Spring(self._primaryModel:ObservePercentPressedTarget(), 40, 0.8)
+	local primaryPercentSelected = Blend.Spring(self._primaryModel:ObservePercentChoosenTarget(), 40, 0.8)
+	local secondaryPercentHighlighted = Blend.AccelTween(self._secondaryModel:ObservePercentHighlightedTarget(), 400)
+	local secondaryPercentPressed = Blend.Spring(self._secondaryModel:ObservePercentPressedTarget(), 40, 0.8)
 
 	return Blend.New "Frame" {
 		Name = "CommandPalette";
@@ -442,25 +795,74 @@ function CommandPalette:Render(props)
 							VerticalAlignment = Enum.VerticalAlignment.Center;
 						};
 
-						Blend.New "ImageLabel" {
-							Name = "searchIcon";
-							BackgroundTransparency = 1;
-							Image = "rbxassetid://6031154871";
-							ImageColor3 = Color3.fromRGB(150, 150, 150);
-							ImageTransparency = transparency;
-							Size = UDim2.fromScale(1, 1);
+						Blend.New "TextButton" {
+							Name = "primaryAction";
+							AnchorPoint = Vector2.new(1, 0.5);
+							BackgroundColor3 = Color3.fromRGB(40, 40, 40);
+							Interactable = self._customResultsEnabled;
+							LayoutOrder = 1;
+							Position = UDim2.fromScale(1, 0);
+							Size = UDim2.new(1, 5, 1, 5);
+							Text = "";
+							Visible = buttonVisible;
+							ZIndex = 5;
+
+							BackgroundTransparency = Blend.Computed(transparency, primaryPercentHighlighted, primaryPercentSelected, function(percent, percentHighlight, percentSelected)
+								return 1 - percentHighlight + percent - percentSelected
+							end);
+
+							[Blend.OnEvent "Activated"] = function()
+								if self._customResultsEnabled.Value then
+									self:SetCustomResults(nil)
+								end
+							end;
+
+							[Blend.Instance] = function(button)
+								self._primaryModel:SetButton(button)
+							end;
 
 							Blend.New "UIAspectRatioConstraint" {
 								AspectRatio = 1;
 							};
-						};
 
+							Blend.New "UICorner" {
+								CornerRadius = UDim.new(0, 5);
+							};
+
+							Blend.New "ImageLabel" {
+								Name = "icon";
+								AnchorPoint = Vector2.new(0.5, 0.5);
+								BackgroundTransparency = 1;
+								Image = self._primaryIcon;
+								ImageTransparency = transparency;
+								Position = UDim2.fromScale(0.5, 0.5);
+								Size = UDim2.fromScale(1, 1);
+
+								ImageColor3 = Blend.Computed(primaryPercentHighlighted, function(percentHighlight)
+									return Color3.fromRGB(75, 75, 75):Lerp(Color3.fromRGB(150, 150, 150), percentHighlight)
+								end);
+
+								Blend.New "UIScale" {
+									Scale = Blend.Computed(primaryPercentPressed, function(percent)
+										return 1 - (percent * 0.15)
+									end);
+								};
+							};
+
+							Blend.New "UIPadding" {
+								PaddingBottom = UDim.new(0, 3);
+								PaddingLeft = UDim.new(0, 3);
+								PaddingRight = UDim.new(0, 3);
+								PaddingTop = UDim.new(0, 3);
+							};
+						};
 						Blend.New "TextBox" {
 							Name = "input";
 							BackgroundTransparency = 1;
 							FontFace = Font.new("rbxasset://fonts/families/SourceSansPro.json");
+							LayoutOrder = 2;
 							PlaceholderColor3 = Color3.fromRGB(80, 80, 80);
-							PlaceholderText = "select a command...";
+							PlaceholderText = self._actionText;
 							Position = UDim2.fromScale(0.04, 0);
 							Size = UDim2.fromScale(0.9, 1);
 							TextColor3 = Color3.fromRGB(220, 220, 220);
@@ -482,6 +884,14 @@ function CommandPalette:Render(props)
 
 								if safeText == " " then
 									safeText = ""
+								end
+
+								if self._customResultsEnabled.Value then
+									if not self._lastSearchQuery then
+										self._lastSearchQuery = self._searchQuery.Value
+									end
+								else
+									self._lastSearchQuery = nil
 								end
 
 								self._searchQuery.Value = safeText
@@ -508,8 +918,20 @@ function CommandPalette:Render(props)
 								local refocusInput = false
 								local shiftPressed = false
 
+								-- Hold shift to trigger without closing the palette
+								for _, inputObject in UserInputService:GetKeysPressed() do
+									if inputObject.KeyCode == Enum.KeyCode.LeftShift then
+										shiftPressed = true
+										break
+									end
+								end
+
+								if shiftPressed then
+									refocusInput = true
+								end
+
 								if enterPressed and selectedEntry then
-									if selectedEntry:IsGroupHeader() then
+									if not selectedEntry.CustomResultType and selectedEntry:IsGroupHeader() then
 										local selectedGroup = self._selectedGroupEntryIndex.Value
 										local groupEntry = self._entries:GetList()[selectedGroup]
 
@@ -520,23 +942,26 @@ function CommandPalette:Render(props)
 										groupEntry:SetIsCollapsed(not groupEntry:IsCollapsed())
 										refocusInput = true
 									else
-										-- Hold shift to trigger without closing the palette
-										for _, inputObject in UserInputService:GetKeysPressed() do
-											if inputObject.KeyCode == Enum.KeyCode.LeftShift then
-												shiftPressed = true
-												break
-											end
-										end
-
 										selectedEntry.Activated:Fire(shiftPressed)
-										if shiftPressed then
-											refocusInput = true
+									end
+								elseif enterPressed then
+									if self._customResultsEnabled.Value then
+										local customResultsType = self._currentCustomResults.Value
+										if customResultsType == "Color" then
+											local currentText = self._input.Text
+											if SearchUtils.stringIsRGB(currentText) then
+												local _, r, g, b = SearchUtils.stringIsRGB(currentText)
+												self.CustomResultActivated:Fire("Color", shiftPressed, Color3.fromRGB(r, g, b))
+											elseif SearchUtils.stringIsHex(currentText) then
+												local _, hex = SearchUtils.stringIsHex(currentText)
+												self.CustomResultActivated:Fire("Color", shiftPressed, Color3.fromHex(hex))
+											end
 										end
 									end
 								end
 
 								if refocusInput then
-									task.spawn(function()
+									task.defer(function()
 										RunService.RenderStepped:Wait()
 										self._input:CaptureFocus()
 									end)
@@ -547,16 +972,17 @@ function CommandPalette:Render(props)
 						};
 
 						Blend.New "TextButton" {
-							Name = "toggleDetails";
+							Name = "secondaryAction";
 							AnchorPoint = Vector2.new(1, 0.5);
 							BackgroundColor3 = Color3.fromRGB(40, 40, 40);
+							LayoutOrder = 3;
 							Position = UDim2.fromScale(1, 0);
 							Size = UDim2.new(1, 5, 1, 5);
 							Text = "";
 							Visible = buttonVisible;
 							ZIndex = 5;
 
-							BackgroundTransparency = Blend.Computed(transparency, detailsPercentHighlighted, function(percent, percentHighlight)
+							BackgroundTransparency = Blend.Computed(transparency, secondaryPercentHighlighted, function(percent, percentHighlight)
 								return 1 - percentHighlight + percent
 							end);
 
@@ -565,7 +991,7 @@ function CommandPalette:Render(props)
 							end;
 
 							[Blend.Instance] = function(button)
-								self._detailsModel:SetButton(button)
+								self._secondaryModel:SetButton(button)
 							end;
 
 							Blend.New "UIAspectRatioConstraint" {
@@ -585,12 +1011,12 @@ function CommandPalette:Render(props)
 								Position = UDim2.fromScale(0.5, 0.5);
 								Size = UDim2.fromScale(1, 1);
 
-								ImageColor3 = Blend.Computed(detailsPercentHighlighted, function(percentHighlight)
+								ImageColor3 = Blend.Computed(secondaryPercentHighlighted, function(percentHighlight)
 									return Color3.fromRGB(75, 75, 75):Lerp(Color3.fromRGB(150, 150, 150), percentHighlight)
 								end);
 
 								Blend.New "UIScale" {
-									Scale = Blend.Computed(detailsPercentPressed, function(percent)
+									Scale = Blend.Computed(secondaryPercentPressed, function(percent)
 										return 1 - (percent * 0.15)
 									end);
 								};
@@ -608,8 +1034,23 @@ function CommandPalette:Render(props)
 					Blend.New "TextButton" {
 						Name = "button";
 						BackgroundTransparency = 1;
-						Size = UDim2.new(1, -35, 1, 0);
 						ZIndex = 5;
+
+						Position = Blend.Computed(self._inputFocused, self._customResultsEnabled, function(isFocused, customResults)
+							if isFocused or customResults then
+								return UDim2.new(0, 35, 0, 0)
+							else
+								return UDim2.fromOffset(0, 0)
+							end
+						end);
+
+						Size = Blend.Computed(self._inputFocused, self._customResultsEnabled, function(isFocused, customResults)
+							if isFocused then
+								return UDim2.new(1, -70, 1, 0)
+							else
+								return UDim2.new(1, -35, 1, 0)
+							end
+						end);
 
 						Visible = Blend.Computed(self:ObserveVisible(), self._inputFocused, function(isVisible, isFocused)
 							if not isVisible then
@@ -687,10 +1128,32 @@ function CommandPalette:Render(props)
 						self._entries:ObserveItemsBrio():Pipe({
 							RxBrioUtils.map(function(groupEntry)
 								return groupEntry:Render({
+									CustomResult = self._currentCustomResults;
 									EntryHeight = self._entryHeight;
+									FontPreviewText = self._fontPreviewText;
 									FzyConfig = FZY_CONFIG;
 									SearchQuery = self._searchQuery;
-									TargetParent = self._targetEntryParent;
+									Transparency = transparency;
+
+									Enabled = Blend.Computed(self._customResultsEnabled, self._currentCustomResults, function(isEnabled, customResults)
+										if customResults and groupEntry.CustomResultType == customResults then
+											return isEnabled
+										else
+											return not isEnabled
+										end
+									end);
+
+									TargetParent = Blend.Computed(self._targetEntryParent, self._customResultsEnabled, self._currentCustomResults, function(targetParent, isEnabled, customResultType)
+										if groupEntry.CustomResultType then
+											if isEnabled then
+												return customResultType == groupEntry.CustomResultType and self._entriesFrame or nil
+											else
+												return nil
+											end
+										else
+											return not isEnabled and targetParent or nil
+										end
+									end);
 								})
 							end);
 						});

--- a/src/StudioMacros/modules/Shared/CommandPalette/CommandPalette.luau
+++ b/src/StudioMacros/modules/Shared/CommandPalette/CommandPalette.luau
@@ -53,6 +53,7 @@ function CommandPalette.new()
 	self._selectedEntry = self._maid:Add(ValueObject.new(nil))
 	self._selectedEntryIndex = self._maid:Add(ValueObject.new(0))
 	self._selectedGroupEntryIndex = self._maid:Add(ValueObject.new(0))
+	self._tabbed = self._maid:Add(Signal.new())
 	self._targetEntryParent = self._maid:Add(ValueObject.new(nil))
 
 	self.CustomResultActivated = self._maid:Add(Signal.new())
@@ -212,6 +213,7 @@ function CommandPalette:_handleInput()
 		local keysPressed = UserInputService:GetKeysPressed()
 		local upPressed, downPressed, ctrlPressed = false, false, false
 		local shiftPressed = false
+		local tabPressed = false
 
 		if input.KeyCode == Enum.KeyCode.Up then
 			upPressed = true
@@ -219,12 +221,24 @@ function CommandPalette:_handleInput()
 			downPressed = true
 		end
 
-		-- Ctrl+J/Ctrl+K support
 		for _, inputObject in keysPressed do
 			if inputObject.KeyCode == Enum.KeyCode.LeftControl or inputObject.KeyCode == Enum.KeyCode.RightControl then
 				ctrlPressed = true
 			elseif inputObject.KeyCode == Enum.KeyCode.LeftShift then
 				shiftPressed = true
+			elseif inputObject.KeyCode == Enum.KeyCode.Tab then
+				tabPressed = true
+			end
+		end
+
+		if tabPressed then
+			if self._inputFocused.Value then
+				self._tabbed:Fire()
+				task.spawn(function()
+					RunService.RenderStepped:Wait()
+					local inputText = self._input.Text
+					self._input.Text = string.sub(inputText, 0, #inputText - 1)
+				end)
 			end
 		end
 
@@ -437,6 +451,11 @@ function CommandPalette:_setupColorResults()
 	if self._bodyFrame then
 		self._colorPicker:SetTargetParent(self._bodyFrame)
 	end
+
+	self._maid:GiveTask(colorPickerPane.TabReturned:Connect(function()
+		print("tab returned")
+		self:CaptureFocus()
+	end))
 
 	self._maid:GiveTask(self._currentCustomResults:ObserveBrio():Subscribe(function(customResultsBrio)
 		if customResultsBrio:IsDead() then
@@ -967,7 +986,7 @@ function CommandPalette:Render(props)
 							[Blend.OnEvent "FocusLost"] = function(enterPressed)
 								local selectedEntry = self._selectedEntry.Value
 								local refocusInput = false
-								local escapePressed, shiftPressed = false
+								local escapePressed, shiftPressed, tabPressed
 
 								-- Hold shift to trigger without closing the palette
 								for _, inputObject in UserInputService:GetKeysPressed() do
@@ -975,7 +994,13 @@ function CommandPalette:Render(props)
 										shiftPressed = true
 									elseif inputObject.KeyCode == Enum.KeyCode.Escape then
 										escapePressed = true
+									elseif inputObject.KeyCode == Enum.KeyCode.Tab then
+										tabPressed = true
 									end
+								end
+
+								if tabPressed then
+									return
 								end
 
 								if shiftPressed and not escapePressed then
@@ -1201,6 +1226,7 @@ function CommandPalette:Render(props)
 									FontPreviewText = self._fontPreviewText;
 									FzyConfig = FZY_CONFIG;
 									SearchQuery = self._searchQuery;
+									Tabbed = self._tabbed;
 									Transparency = transparency;
 
 									Enabled = Blend.Computed(self._customResultsEnabled, self._currentCustomResults, function(isEnabled, customResults)

--- a/src/StudioMacros/modules/Shared/CommandPalette/Input/Color/ColorEntry.luau
+++ b/src/StudioMacros/modules/Shared/CommandPalette/Input/Color/ColorEntry.luau
@@ -1,5 +1,7 @@
 local require = require(script.Parent.loader).load(script)
 
+local UserInputService = game:GetService("UserInputService")
+
 local BasicPane = require("BasicPane")
 local Blend = require("Blend")
 local ButtonHighlightModel = require("ButtonHighlightModel")
@@ -249,7 +251,15 @@ function ColorEntry:Render(props)
 			ZIndex = 5;
 
 			[Blend.OnEvent "Activated"] = function()
-				self.Activated:Fire()
+				local shiftPressed = false
+				for _, inputObject in UserInputService:GetKeysPressed() do
+					if inputObject.KeyCode == Enum.KeyCode.LeftShift then
+						shiftPressed = true
+						break
+					end
+				end
+
+				self.Activated:Fire(shiftPressed)
 			end;
 
 			[Blend.Instance] = function(button)

--- a/src/StudioMacros/modules/Shared/CommandPalette/Input/Color/ColorEntry.luau
+++ b/src/StudioMacros/modules/Shared/CommandPalette/Input/Color/ColorEntry.luau
@@ -1,0 +1,262 @@
+local require = require(script.Parent.loader).load(script)
+
+local BasicPane = require("BasicPane")
+local Blend = require("Blend")
+local ButtonHighlightModel = require("ButtonHighlightModel")
+local Fzy = require("Fzy")
+local SearchUtils = require("SearchUtils")
+local Signal = require("Signal")
+local ValueObject = require("ValueObject")
+
+local ColorEntry = setmetatable({}, BasicPane)
+ColorEntry.ClassName = "ColorEntry"
+ColorEntry.CustomResultType = "Color"
+ColorEntry.__index = ColorEntry
+
+function ColorEntry.new()
+	local self = setmetatable(BasicPane.new(), ColorEntry)
+
+	self._colorName = self._maid:Add(ValueObject.new(""))
+	self._defaultIndex = self._maid:Add(ValueObject.new(0))
+	self._model = self._maid:Add(ButtonHighlightModel.new())
+	self._percentVisibleTarget = self._maid:Add(ValueObject.new(0))
+	self._yPosition = self._maid:Add(ValueObject.new(0))
+
+	self.Activated = self._maid:Add(Signal.new())
+	self.Color = self._maid:Add(ValueObject.new(Color3.new(1, 1, 1)))
+	self.SearchScore = self._maid:Add(ValueObject.new(0))
+
+	self._maid:GiveTask(self.VisibleChanged:Connect(function(isVisible)
+		self._model:SetInteractionEnabled(isVisible)
+		self._percentVisibleTarget.Value = isVisible and 1 or 0
+	end))
+
+	return self
+end
+
+function ColorEntry:SetColorName(colorName: string)
+	self._colorName.Value = colorName
+end
+
+function ColorEntry:SetColor(color: Color3)
+	self.Color.Value = color
+end
+
+function ColorEntry:GetYPosition()
+	return self._yPosition.Value
+end
+
+function ColorEntry:SetDefaultIndex(index: number)
+	self._defaultIndex.Value = index
+end
+
+function ColorEntry:SetIsSelected(isSelected: boolean)
+	self._model:SetIsChoosen(isSelected)
+	self._model._isMouseOver.Value = isSelected
+end
+
+function ColorEntry:GetData()
+	return self.Color.Value
+end
+
+function ColorEntry:Render(props)
+	local target = self._percentVisibleTarget:Observe()
+
+	local percentHighlighted = Blend.Spring(self._model:ObservePercentHighlightedTarget(), 35, 0.7)
+	local percentPressed = Blend.Spring(self._model:ObservePercentPressedTarget(), 35, 0.55)
+	local percentSelected = Blend.AccelTween(self._model:ObservePercentChoosenTarget(), 400)
+
+	local foregroundColor = Blend.Computed(percentSelected, function(percent)
+		return Color3.fromRGB(150, 150, 150):Lerp(Color3.fromRGB(255, 255, 255), percent)
+	end);
+
+	local fzyConfig = props.FzyConfig
+	local transparency = props.Transparency
+
+	self._maid:GiveTask(Blend.Computed(self._colorName, props.SearchQuery, function(colorName, searchQuery)
+		if searchQuery == "" then
+			self.SearchScore.Value = nil
+			return
+		end
+
+		self.SearchScore.Value = Fzy.score(fzyConfig, searchQuery, string.lower(colorName))
+	end):Subscribe())
+
+	local verticalPadding = Blend.Computed(props.EntryHeight, function(height)
+		return UDim.new(0, height == 45 and 14 or 10)
+	end);
+
+	return Blend.New "Frame" {
+		Name = "ColorEntry";
+		BackgroundTransparency = 1;
+		Parent = props.TargetParent;
+
+		LayoutOrder = Blend.Computed(self.SearchScore, self._defaultIndex, function(score, defaultIndex)
+			return score and -(score * 10000) or defaultIndex
+		end);
+
+		Size = Blend.Computed(props.EntryHeight, function(height)
+			return UDim2.new(1, 0, 0, height)
+		end);
+
+		Visible = Blend.Computed(props.CustomResult, props.Enabled, props.SearchQuery, self.SearchScore, function(customResult, isEnabled, searchQuery, searchScore)
+			if not customResult then
+				return false
+			elseif isEnabled then
+				if searchQuery ~= "" and searchScore then
+					return searchScore > 0
+				else
+					return true
+				end
+			end
+
+			return false
+		end);
+
+		ZIndex = Blend.Computed(self.SearchScore, self._defaultIndex, function(score, defaultIndex)
+			return score and -(score * 10000) or defaultIndex
+		end);
+
+		[Blend.OnChange "AbsolutePosition"] = function(position)
+			if not self:IsVisible() then
+				return
+			end
+
+			self._yPosition.Value = math.round(position.Y)
+		end;
+
+		Blend.New "Frame" {
+			Name = "wrapper";
+			BackgroundColor3 = Color3.fromRGB(50, 50, 50);
+			Size = UDim2.fromScale(1, 1);
+
+			BackgroundTransparency = Blend.Computed(transparency, percentHighlighted, function(percent, percentHighlight)
+				return 1 - percentHighlight + percent
+			end);
+
+			Blend.New "UIListLayout" {
+				FillDirection = Enum.FillDirection.Horizontal;
+				HorizontalFlex = Enum.UIFlexAlignment.Fill;
+				Padding = UDim.new(0, 10);
+				VerticalAlignment = Enum.VerticalAlignment.Center;
+			};
+
+			Blend.New "UIPadding" {
+				PaddingBottom = verticalPadding;
+				PaddingLeft = UDim.new(0, 7);
+				PaddingRight = UDim.new(0, 7);
+				PaddingTop = verticalPadding;
+			};
+
+			Blend.New "UIStroke" {
+				Color = Color3.fromRGB(85, 85, 85);
+				Transparency = Blend.Computed(transparency, percentHighlighted, function(percent, percentHighlight)
+					return math.clamp(1 - percentHighlight + percent, 0, 1)
+				end);
+			};
+
+			Blend.New "UICorner" {
+				CornerRadius = UDim.new(0, 5);
+			};
+
+			Blend.New "Frame" {
+				Name = "colorPreview";
+				BackgroundColor3 = self.Color;
+				BackgroundTransparency = transparency;
+				Size = UDim2.fromScale(1.5, 1.5);
+
+				Blend.New "UIAspectRatioConstraint" {
+					AspectRatio = 1;
+				};
+
+				Blend.New "UICorner" {
+					CornerRadius = UDim.new(0, 5);
+				};
+			};
+
+			Blend.New "Frame" {
+				Name = "container";
+				BackgroundTransparency = 1;
+				LayoutOrder = 3;
+				Size = UDim2.fromScale(0.85, 1);
+
+				Blend.New "TextLabel" {
+					Name = "colorName";
+					AnchorPoint = Vector2.new(0, 0.5);
+					BackgroundTransparency = 1;
+					FontFace = Font.new("rbxasset://fonts/families/SourceSansPro.json");
+					LayoutOrder = 2;
+					Position = UDim2.fromScale(0, 0.5);
+					RichText = true;
+					Size = UDim2.new(1, 0, 0, 15);
+					TextColor3 = Color3.fromRGB(255, 255, 255);
+					TextSize = 15;
+					TextTransparency = transparency;
+					TextWrapped = true;
+					TextXAlignment = Enum.TextXAlignment.Left;
+
+					Text = Blend.Computed(self._colorName, props.SearchQuery, function(colorName, searchQuery)
+						if searchQuery ~= "" then
+							return SearchUtils.getMatchedString(fzyConfig, colorName, searchQuery)
+						else
+							return colorName
+						end
+					end);
+				};
+
+				Blend.New "TextLabel" {
+					Name = "colorValue";
+					AnchorPoint = Vector2.new(1, 0.5);
+					BackgroundTransparency = 1;
+					FontFace = Font.new("rbxasset://fonts/families/SourceSansPro.json");
+					LayoutOrder = 2;
+					Position = UDim2.fromScale(1, 0.5);
+					Size = UDim2.new(1, 0, 0, 15);
+					TextSize = 13;
+					TextTransparency = transparency;
+					TextWrapped = true;
+					TextXAlignment = Enum.TextXAlignment.Right;
+
+					Text = Blend.Computed(self.Color, function(color)
+						if not color then
+							return ""
+						end
+
+						return `{math.round(color.R * 255)}, {math.round(color.G * 255)}, {math.round(color.B * 255)}`
+					end);
+
+					TextColor3 = Blend.Computed(percentSelected, function(percent)
+						return Color3.fromRGB(110, 110, 110):Lerp(Color3.fromRGB(255, 255, 255), percent)
+					end);
+				};
+			};
+		};
+
+		Blend.New "Frame" {
+			Name = "divider";
+			AnchorPoint = Vector2.new(0, 1);
+			BackgroundColor3 = Color3.fromRGB(35, 35, 35);
+			BackgroundTransparency = transparency;
+			Position = UDim2.new(0, 0, 1, 2);
+			Size = UDim2.new(1, 0, 0, 1);
+		};
+
+		Blend.New "TextButton" {
+			Name = "button";
+			BackgroundTransparency = 1;
+			Size = UDim2.fromScale(1, 1);
+			Visible = props.Enabled;
+			ZIndex = 5;
+
+			[Blend.OnEvent "Activated"] = function()
+				self.Activated:Fire()
+			end;
+
+			[Blend.Instance] = function(button)
+				self._model:SetButton(button)
+			end;
+		};
+	}
+end
+
+return ColorEntry

--- a/src/StudioMacros/modules/Shared/CommandPalette/Input/Color/ColorPickerPane.luau
+++ b/src/StudioMacros/modules/Shared/CommandPalette/Input/Color/ColorPickerPane.luau
@@ -1,11 +1,13 @@
 local require = require(script.Parent.loader).load(script)
 
+local RunService = game:GetService("RunService")
 local TweenService = game:GetService("TweenService")
 local UserInputService = game:GetService("UserInputService")
 
 local BasicPane = require("BasicPane")
 local Blend = require("Blend")
 local Rx = require("Rx")
+local SearchUtils = require("SearchUtils")
 local Signal = require("Signal")
 local SpringObject = require("SpringObject")
 local ValueObject = require("ValueObject")
@@ -22,15 +24,50 @@ ColorPickerPane.__index = ColorPickerPane
 function ColorPickerPane.new()
 	local self = setmetatable(BasicPane.new(), ColorPickerPane)
 
+	self._tabInputMap = {}
+
 	self._currentBrightness = self._maid:Add(ValueObject.new(nil))
 	self._currentHue = self._maid:Add(ValueObject.new(nil))
 	self._currentSaturation = self._maid:Add(ValueObject.new(nil))
 	self._percentVisibleTarget = self._maid:Add(ValueObject.new(0))
+	self._tabInputIndex = self._maid:Add(ValueObject.new(nil))
 	self._targetParent = self._maid:Add(ValueObject.new(nil))
 	self._yPosition = self._maid:Add(ValueObject.new(0))
 
 	self.ColorUpdated = self._maid:Add(Signal.new())
 	self.CurrentColor = self._maid:Add(ValueObject.new(Color3.new(1, 1, 1)))
+	self.TabReturned = self._maid:Add(Signal.new())
+
+	self._maid:GiveTask(self._tabInputIndex:Observe():Subscribe(function(index)
+		if not index then
+			return
+		end
+
+		if index == 0 then
+			self.TabReturned:Fire()
+			return
+		end
+
+		local input = self._tabInputMap[index]
+		if input then
+			task.spawn(function()
+				RunService.RenderStepped:Wait()
+				input:CaptureFocus()
+			end)
+		end
+	end))
+
+	self._maid:GiveTask(UserInputService.InputBegan:Connect(function(input)
+		if input.UserInputType == Enum.UserInputType.Keyboard then
+			local shiftPressed = self:_shiftPressed()
+
+			if input.KeyCode == Enum.KeyCode.Tab then
+				if shiftPressed then
+					self._tabInputIndex.Value = math.clamp(self._tabInputIndex.Value - 1, 0, #self._tabInputMap)
+				end
+			end
+		end
+	end))
 
 	self._maid:GiveTask(UserInputService.InputChanged:Connect(function(input)
 		if not self:IsVisible() then
@@ -174,6 +211,19 @@ function ColorPickerPane:Render(props)
 			return math.abs(percent - 1)
 		end);
 	}), 50, 0.9)
+
+	self._maid._tabbed = props.Tabbed:Connect(function()
+		if self:_shiftPressed() then
+			return
+		end
+
+		if not self._tabInputIndex.Value then
+			self._tabInputIndex.Value = 1
+			return
+		end
+
+		self._tabInputIndex.Value = math.clamp(self._tabInputIndex.Value + 1, 0, #self._tabInputMap)
+	end)
 
 	return Blend.New "Frame" {
 		Name = "ColorPickerPane";
@@ -669,6 +719,53 @@ function ColorPickerPane:Render(props)
 						PlaceholderText = Blend.Computed(targetColor, function(color)
 							return `{math.round(color.R * 255)}, {math.round(color.G * 255)}, {math.round(color.B * 255)}`
 						end);
+
+						[Blend.Instance] = function(textBox)
+							self._rgbInput = textBox
+							table.insert(self._tabInputMap, 1, textBox)
+						end;
+
+						[Blend.OnChange "Text"] = function(newText)
+							if not self._rgbInput then
+								return
+							end
+
+							if newText == self._rgbInput.PlaceholderText then
+								return
+							end
+
+							if SearchUtils.stringIsRGB(self._rgbInput.Text) then
+								local _, r, g, b = SearchUtils.stringIsRGB(self._rgbInput.Text)
+								self:SetColor(Color3.fromRGB(r, g, b))
+							end
+						end;
+
+						[Blend.OnEvent "Focused"] = function()
+							self:_handleFocused(self._rgbInput)
+						end;
+
+						[Blend.OnEvent "FocusLost"] = function(enterPressed)
+							if not self._rgbInput then
+								return
+							end
+
+							if enterPressed then
+								if self._rgbInput.Text ~= self._rgbInput.PlaceholderText then
+									if SearchUtils.stringIsRGB(self._rgbInput.Text) then
+										local _, r, g, b = SearchUtils.stringIsRGB(self._rgbInput.Text)
+										self:SetColor(Color3.fromRGB(r, g, b))
+									end
+
+									self._rgbInput.Text = ""
+								else
+									self._rgbInput.Text = ""
+								end
+							else
+								self._rgbInput.Text = ""
+							end
+						end;
+
+						self:_handleFocusLost()
 					};
 				};
 
@@ -734,6 +831,53 @@ function ColorPickerPane:Render(props)
 						PlaceholderText = Blend.Computed(targetColor, function(color)
 							return color:ToHex()
 						end);
+
+						[Blend.Instance] = function(textBox)
+							self._hexInput = textBox
+							table.insert(self._tabInputMap, 2, textBox)
+						end;
+
+						[Blend.OnChange "Text"] = function(newText)
+							if not self._hexInput then
+								return
+							end
+
+							if newText == self._hexInput.PlaceholderText then
+								return
+							end
+
+							if SearchUtils.stringIsHex(self._hexInput.Text) then
+								local _, hex = SearchUtils.stringIsHex(self._hexInput.Text)
+								self:SetColor(Color3.fromHex(hex))
+							end
+						end;
+
+						[Blend.OnEvent "Focused"] = function()
+							self:_handleFocused(self._hexInput)
+						end;
+
+						[Blend.OnEvent "FocusLost"] = function(enterPressed)
+							if not self._hexInput then
+								return
+							end
+
+							if enterPressed then
+								if self._hexInput.Text ~= self._hexInput.PlaceholderText then
+									if SearchUtils.stringIsHex(self._hexInput.Text) then
+										local _, hex = SearchUtils.stringIsHex(self._hexInput.Text)
+										self:SetColor(Color3.fromHex(hex))
+									end
+
+									self._hexInput.Text = ""
+								else
+									self._hexInput.Text = ""
+								end
+							else
+								self._hexInput.Text = ""
+							end
+
+							self:_handleFocusLost()
+						end;
 					};
 				};
 
@@ -790,6 +934,62 @@ function ColorPickerPane:Render(props)
 							PlaceholderText = Blend.Computed(targetColor, function(color)
 								return `{math.round(color.R * 255)}`
 							end);
+
+							[Blend.Instance] = function(textBox)
+								self._rInput = textBox
+								table.insert(self._tabInputMap, 3, textBox)
+							end;
+
+							[Blend.OnChange "Text"] = function(newText)
+								if not self._rInput or not self._rInput:IsFocused() then
+									return
+								end
+
+								if newText == self._rInput.PlaceholderText then
+									return
+								end
+
+								if tonumber(newText) then
+									local currentColor = self.CurrentColor.Value
+									local r, g, b = math.clamp(tonumber(newText), 0, 255),
+										math.clamp(math.round(currentColor.G * 255), 0, 255),
+										math.clamp(math.round(currentColor.B * 255), 0, 255)
+
+									self:SetColor(Color3.fromRGB(r, g, b))
+								end
+							end;
+
+							[Blend.OnEvent "Focused"] = function()
+								self:_handleFocused(self._rInput)
+							end;
+
+							[Blend.OnEvent "FocusLost"] = function(enterPressed)
+								if not self._rInput then
+									return
+								end
+
+								local text = self._rInput.Text
+								if enterPressed then
+									if text ~= self._rInput.PlaceholderText then
+										if tonumber(text) then
+											local currentColor = self.CurrentColor.Value
+											local r, g, b = math.clamp(tonumber(text), 0, 255),
+												math.clamp(math.round(currentColor.G * 255), 0, 255),
+												math.clamp(math.round(currentColor.B * 255), 0, 255)
+
+											self:SetColor(Color3.fromRGB(r, g, b))
+										end
+
+										self._rInput.Text = ""
+									else
+										self._rInput.Text = ""
+									end
+								else
+									self._rInput.Text = ""
+								end
+
+								self:_handleFocusLost()
+							end;
 						};
 					};
 
@@ -832,6 +1032,62 @@ function ColorPickerPane:Render(props)
 							PlaceholderText = Blend.Computed(targetColor, function(color)
 								return `{math.round(color.G * 255)}`
 							end);
+
+							[Blend.Instance] = function(textBox)
+								self._gInput = textBox
+								table.insert(self._tabInputMap, 4, textBox)
+							end;
+
+							[Blend.OnChange "Text"] = function(newText)
+								if not self._gInput or not self._gInput:IsFocused() then
+									return
+								end
+
+								if newText == self._gInput.PlaceholderText then
+									return
+								end
+
+								if tonumber(newText) then
+									local currentColor = self.CurrentColor.Value
+									local r, g, b = math.clamp(math.round(currentColor.R * 255), 0, 255),
+										math.clamp(tonumber(newText), 0, 255),
+										math.clamp(math.round(currentColor.B * 255), 0, 255)
+
+									self:SetColor(Color3.fromRGB(r, g, b))
+								end
+							end;
+
+							[Blend.OnEvent "Focused"] = function()
+								self:_handleFocused(self._gInput)
+							end;
+
+							[Blend.OnEvent "FocusLost"] = function(enterPressed)
+								if not self._gInput then
+									return
+								end
+
+								local text = self._gInput.Text
+								if enterPressed then
+									if text ~= self._gInput.PlaceholderText then
+										if tonumber(text) then
+											local currentColor = self.CurrentColor.Value
+											local r, g, b = math.clamp(math.round(currentColor.R * 255), 0, 255),
+												math.clamp(tonumber(text), 0, 255),
+												math.clamp(math.round(currentColor.B * 255), 0, 255)
+
+											self:SetColor(Color3.fromRGB(r, g, b))
+										end
+
+										self._gInput.Text = ""
+									else
+										self._gInput.Text = ""
+									end
+								else
+									self._gInput.Text = ""
+								end
+
+								self:_handleFocusLost()
+							end;
 						};
 					};
 
@@ -874,6 +1130,62 @@ function ColorPickerPane:Render(props)
 							PlaceholderText = Blend.Computed(targetColor, function(color)
 								return `{math.round(color.B * 255)}`
 							end);
+
+							[Blend.Instance] = function(textBox)
+								self._bInput = textBox
+								table.insert(self._tabInputMap, 5, textBox)
+							end;
+
+							[Blend.OnChange "Text"] = function(newText)
+								if not self._bInput or not self._bInput:IsFocused() then
+									return
+								end
+
+								if newText == self._bInput.PlaceholderText then
+									return
+								end
+
+								if tonumber(newText) then
+									local currentColor = self.CurrentColor.Value
+									local r, g, b = math.clamp(math.round(currentColor.R * 255), 0, 255),
+										math.clamp(math.round(currentColor.G * 255), 0, 255),
+										math.clamp(tonumber(newText), 0, 255)
+
+									self:SetColor(Color3.fromRGB(r, g, b))
+								end
+							end;
+
+							[Blend.OnEvent "Focused"] = function()
+								self:_handleFocused(self._bInput)
+							end;
+
+							[Blend.OnEvent "FocusLost"] = function(enterPressed)
+								if not self._bInput then
+									return
+								end
+
+								local text = self._bInput.Text
+								if enterPressed then
+									if text ~= self._bInput.PlaceholderText then
+										if tonumber(text) then
+											local currentColor = self.CurrentColor.Value
+											local r, g, b = math.clamp(math.round(currentColor.R * 255), 0, 255),
+												math.clamp(math.round(currentColor.G * 255), 0, 255),
+												math.clamp(tonumber(text), 0, 255)
+
+											self:SetColor(Color3.fromRGB(r, g, b))
+										end
+
+										self._bInput.Text = ""
+									else
+										self._bInput.Text = ""
+									end
+								else
+									self._bInput.Text = ""
+								end
+
+								self:_handleFocusLost()
+							end;
 						};
 					};
 				};
@@ -892,8 +1204,42 @@ function ColorPickerPane:Render(props)
 	};
 end
 
+function ColorPickerPane:_handleFocusLost()
+	if not UserInputService:GetFocusedTextBox() then
+		self._tabInputIndex.Value = nil
+	end
+end
+
+function ColorPickerPane:_handleFocused(input)
+	if not input then
+		return
+	end
+
+	if not self._tabInputIndex.Value then
+		local index = table.find(self._tabInputMap, input)
+		self._tabInputIndex.Value = index
+	end
+
+	local placeholder = input.PlaceholderText
+
+	input.Text = placeholder
+	input.SelectionStart = 0
+	input.CursorPosition = #placeholder + 1
+end
+
 function ColorPickerPane:_isValidInput(inputObject)
 	return inputObject.UserInputType == Enum.UserInputType.MouseButton1 or inputObject.UserInputType == Enum.UserInputType.Touch
+end
+
+function ColorPickerPane:_shiftPressed()
+	local shiftPressed = false
+	for _, inputObject in UserInputService:GetKeysPressed() do
+		if inputObject.KeyCode == Enum.KeyCode.LeftShift then
+			shiftPressed = true
+			break
+		end
+	end
+	return shiftPressed
 end
 
 return ColorPickerPane

--- a/src/StudioMacros/modules/Shared/CommandPalette/Input/Color/ColorPickerPane.luau
+++ b/src/StudioMacros/modules/Shared/CommandPalette/Input/Color/ColorPickerPane.luau
@@ -1,10 +1,13 @@
 local require = require(script.Parent.loader).load(script)
 
 local TweenService = game:GetService("TweenService")
+local UserInputService = game:GetService("UserInputService")
 
 local BasicPane = require("BasicPane")
 local Blend = require("Blend")
 local Rx = require("Rx")
+local Signal = require("Signal")
+local SpringObject = require("SpringObject")
 local ValueObject = require("ValueObject")
 
 local TWEEN_INFO = TweenInfo.new(0.2, Enum.EasingStyle.Quart, Enum.EasingDirection.Out)
@@ -12,14 +15,38 @@ local TWEEN_INFO = TweenInfo.new(0.2, Enum.EasingStyle.Quart, Enum.EasingDirecti
 local ColorPickerPane = setmetatable({}, BasicPane)
 ColorPickerPane.ClassName = "ColorPickerPane"
 ColorPickerPane.CustomResultType = "Color"
+ColorPickerPane.Height = 160
+ColorPickerPane.Pinned = true
 ColorPickerPane.__index = ColorPickerPane
 
 function ColorPickerPane.new()
 	local self = setmetatable(BasicPane.new(), ColorPickerPane)
 
-	self._currentColor = self._maid:Add(ValueObject.new(Color3.new(1, 1, 1)))
+	self._currentBrightness = self._maid:Add(ValueObject.new(nil))
+	self._currentHue = self._maid:Add(ValueObject.new(nil))
+	self._currentSaturation = self._maid:Add(ValueObject.new(nil))
 	self._percentVisibleTarget = self._maid:Add(ValueObject.new(0))
+	self._targetParent = self._maid:Add(ValueObject.new(nil))
 	self._yPosition = self._maid:Add(ValueObject.new(0))
+
+	self.ColorUpdated = self._maid:Add(Signal.new())
+	self.CurrentColor = self._maid:Add(ValueObject.new(Color3.new(1, 1, 1)))
+
+	self._maid:GiveTask(UserInputService.InputChanged:Connect(function(input)
+		if not self:IsVisible() then
+			return
+		end
+
+		if input.UserInputType == Enum.UserInputType.MouseMovement or input.UserInputType == Enum.UserInputType.Touch then
+			if self.DraggingHue then
+				self:_updateHuePosition(input)
+			elseif self.DraggingBrightness then
+				self:_updateBrightnessPosition(input)
+			elseif self.DraggingCursor then
+				self:_updateCursorPosition(input)
+			end
+		end
+	end))
 
 	self._maid:GiveTask(self.VisibleChanged:Connect(function(isVisible)
 		self._percentVisibleTarget.Value = isVisible and 1 or 0
@@ -28,12 +55,57 @@ function ColorPickerPane.new()
 	return self
 end
 
+function ColorPickerPane:ObserveColor()
+	return self.CurrentColor:Observe()
+end
+
 function ColorPickerPane:SetColor(color)
-	return self._currentColor:Mount(color)
+	self.CurrentColor.Value = color
 end
 
 function ColorPickerPane:GetYPosition()
 	return self._yPosition.Value
+end
+
+function ColorPickerPane:_updateCursorPosition(inputObject)
+	if not self._color then
+		return
+	end
+
+	local relativeX = inputObject.Position.X - self._color.AbsolutePosition.X
+	local relativeY = inputObject.Position.Y - self._color.AbsolutePosition.Y
+
+	local saturation = math.abs(math.clamp(relativeX / self._color.AbsoluteSize.X, 0, 1) - 1)
+	local value = math.abs(math.clamp(relativeY / self._color.AbsoluteSize.Y, 0, 1) - 1)
+
+	self._currentSaturation.Value = saturation
+	self._currentBrightness.Value = value
+end
+
+function ColorPickerPane:_updateHuePosition(inputObject)
+	if not self._hue then
+		return
+	end
+
+	local relativeY = inputObject.Position.Y - self._hue.AbsolutePosition.Y
+	local hue = math.clamp(relativeY / self._hue.AbsoluteSize.Y, 0, 1)
+
+	self._currentHue.Value = hue
+end
+
+function ColorPickerPane:_updateBrightnessPosition(inputObject)
+	if not self._brightness then
+		return
+	end
+
+	local relativeY = inputObject.Position.Y - self._brightness.AbsolutePosition.Y
+	local value = math.clamp(relativeY / self._brightness.AbsoluteSize.Y, 0, 1)
+
+	self._currentBrightness.Value = math.abs(1 - value)
+end
+
+function ColorPickerPane:SetTargetParent(targetParent)
+	self._targetParent.Value = targetParent
 end
 
 function ColorPickerPane:Render(props)
@@ -43,37 +115,43 @@ function ColorPickerPane:Render(props)
 	local transparency = props.Transparency
 
 	local hue = self._maid:Add(Blend.State(0))
-	local saturation = self._maid:Add(Blend.State(0))
-	local brightness = self._maid:Add(Blend.State(0))
 
-	self._maid:GiveTask(self._currentColor:Observe():Subscribe(function(color)
-		local h, s, v = color:ToHSV()
-
-		hue.Value = h
-		saturation.Value = s
-		brightness.Value = v
-	end))
-
-	local percentHue = Blend.Spring(hue, 35, 0.9)
-	local percentSaturation = Blend.Spring(saturation, 35, 0.9)
-	local percentBrightness = Blend.Spring(brightness, 35, 0.9)
-
-	local pickerCursorX = Blend.Spring(percentSaturation:Pipe({
-		Rx.map(function(percent)
-			return math.abs(percent - 1)
-		end);
-	}), 35, 0.7)
-
-	local pickerCursorY = Blend.Spring(percentBrightness:Pipe({
-		Rx.map(function(percent)
-			return math.abs(percent - 1)
-		end);
-	}), 35, 0.7)
-
-	local oldColor = self._maid:Add(Blend.State(self._currentColor.Value))
+	local oldColor = self._maid:Add(Blend.State(self.CurrentColor.Value))
 	local targetColor = self._maid:Add(Instance.new("Color3Value"))
 
-	self._maid:GiveTask(self._currentColor:Observe():Subscribe(function(newColor)
+	self._maid:GiveTask(Blend.Computed(self._currentHue, self._currentSaturation, self._currentBrightness, function(hue, saturation, brightness)
+		if not hue or not saturation or not brightness then
+			local currentColor = self.CurrentColor.Value
+			if not currentColor then
+				return
+			end
+
+			hue, saturation, brightness = currentColor:ToHSV()
+		end
+
+		self.CurrentColor.Value = Color3.fromHSV(hue, saturation, brightness)
+	end):Subscribe())
+
+	self._maid:GiveTask(self.CurrentColor:Observe():Subscribe(function(newColor)
+		if not newColor then
+			return
+		end
+
+		local h, s, v = newColor:ToHSV()
+		-- Fill default hsv values
+		local currentHue = self._currentHue.Value
+		if not currentHue or h ~= self._currentHue.Value then
+			self._currentHue.Value = h
+		end
+		local currentSaturation = self._currentSaturation.Value
+		if not currentSaturation or s ~= self._currentSaturation.Value then
+			self._currentSaturation.Value = s
+		end
+		local currentBrightness = self._currentBrightness.Value
+		if not currentBrightness or v ~= self._currentBrightness.Value then
+			self._currentBrightness.Value = v
+		end
+
 		TweenService:Create(targetColor, TWEEN_INFO, {
 			Value = newColor
 		}):Play()
@@ -81,13 +159,29 @@ function ColorPickerPane:Render(props)
 		oldColor.Value = newColor
 	end))
 
+	local percentHue = Blend.Spring(self._currentHue, 35, 0.9)
+	local percentSaturation = Blend.Spring(self._currentSaturation, 35, 0.9)
+	local percentBrightness = Blend.Spring(self._currentBrightness, 35, 0.9)
+
+	local pickerCursorX = Blend.Spring(percentSaturation:Pipe({
+		Rx.map(function(percent)
+			return math.abs(percent - 1)
+		end);
+	}), 50, 0.9)
+
+	local pickerCursorY = Blend.Spring(percentBrightness:Pipe({
+		Rx.map(function(percent)
+			return math.abs(percent - 1)
+		end);
+	}), 50, 0.9)
+
 	return Blend.New "Frame" {
 		Name = "ColorPickerPane";
 		BackgroundTransparency = 1;
 		LayoutOrder = -1;
 		LayoutOrder = -9e9;
-		Size = UDim2.new(1, 0, 0, 160);
-		Parent = props.TargetParent;
+		Size = UDim2.new(1, 0, 0, self.Height);
+		Parent = self._targetParent;
 
 		Visible = Blend.Computed(props.CustomResult, props.Enabled, function(customResult, isEnabled)
 			if customResult then
@@ -114,7 +208,7 @@ function ColorPickerPane:Render(props)
 				FillDirection = Enum.FillDirection.Horizontal;
 				HorizontalAlignment = Enum.HorizontalAlignment.Center;
 				HorizontalFlex = Enum.UIFlexAlignment.Fill;
-				Padding = UDim.new(0, 10);
+				Padding = UDim.new(0, 6);
 				VerticalAlignment = Enum.VerticalAlignment.Center;
 			};
 
@@ -130,6 +224,11 @@ function ColorPickerPane:Render(props)
 				Blend.New "UICorner" {
 					CornerRadius = UDim.new(0, 5);
 				};
+
+				Blend.New "UIStroke" {
+					Color = Color3.fromRGB(40, 40, 40);
+					Transparency = transparency;
+				};
 			};
 
 			Blend.New "Frame" {
@@ -137,6 +236,7 @@ function ColorPickerPane:Render(props)
 				BackgroundTransparency = 1;
 				LayoutOrder = 2;
 				Size = UDim2.fromScale(0.5, 1);
+				ZIndex = 3;
 
 				Blend.New "Frame" {
 					Name = "background";
@@ -173,6 +273,11 @@ function ColorPickerPane:Render(props)
 						Blend.New "UICorner" {
 							CornerRadius = UDim.new(0, 4);
 						};
+
+						Blend.New "UIStroke" {
+							Color = Color3.fromRGB(40, 40, 40);
+							Transparency = transparency;
+						};
 					};
 
 					Blend.New "Frame" {
@@ -195,6 +300,24 @@ function ColorPickerPane:Render(props)
 					TextColor3 = Color3.fromRGB(27, 42, 53);
 					TextSize = 8;
 					ZIndex = 5;
+
+					[Blend.Instance] = function(instance)
+						self._color = instance
+					end;
+
+					[Blend.OnEvent "InputBegan"] = function(input)
+						if self:_isValidInput(input) then
+							self.DraggingCursor = true
+							self:_updateCursorPosition(input)
+						end
+					end;
+
+					[Blend.OnEvent "InputEnded"] = function(input)
+						if self:_isValidInput(input) then
+							self.DraggingCursor = false
+							self.ColorUpdated:Fire(self.CurrentColor.Value)
+						end
+					end;
 				};
 
 				Blend.New "Frame" {
@@ -217,16 +340,18 @@ function ColorPickerPane:Render(props)
 					};
 
 					Blend.New "Frame" {
-						Position = UDim2.fromScale(0.5, 0.5);
+						Name = "container";
 						AnchorPoint = Vector2.new(0.5, 0.5);
-						Size = UDim2.fromScale(1, 1);
 						BackgroundTransparency = 1;
+						Position = UDim2.fromScale(0.5, 0.5);
+						Size = UDim2.fromScale(1, 1);
 
 						Blend.New "Frame" {
-							Position = UDim2.fromScale(0.5, 0.5);
+							Name = "dot";
 							AnchorPoint = Vector2.new(0.5, 0.5);
-							Size = UDim2.fromScale(1, 1);
 							BackgroundTransparency = 1;
+							Position = UDim2.fromScale(0.5, 0.5);
+							Size = UDim2.fromScale(1, 1);
 
 							Blend.New "UICorner" {
 								CornerRadius = UDim.new(1, 0);
@@ -245,10 +370,11 @@ function ColorPickerPane:Render(props)
 							};
 
 							Blend.New "Frame" {
-								Position = UDim2.fromScale(0.5, 0.5);
+								Name = "inner";
 								AnchorPoint = Vector2.new(0.5, 0.5);
+								BackgroundTransparency = transparency;
+								Position = UDim2.fromScale(0.5, 0.5);
 								Size = UDim2.fromScale(1, 1);
-								BorderColor3 = Color3.fromRGB(27, 42, 53);
 
 								Blend.New "UICorner" {
 									CornerRadius = UDim.new(1, 0);
@@ -274,25 +400,31 @@ function ColorPickerPane:Render(props)
 
 			Blend.New "Frame" {
 				Name = "sliders";
+				BackgroundTransparency = 1;
 				LayoutOrder = 3;
 				Position = UDim2.fromScale(0.5, 0);
 				Size = UDim2.new(0, 40, 1, 0);
-				BackgroundTransparency = 1;
+				ZIndex = 2;
 
 				Blend.New "UIFlexItem" { };
 
 				Blend.New "Frame" {
 					Name = "hue";
-					Position = UDim2.fromScale(0, 1);
 					AnchorPoint = Vector2.new(0, 1);
-					Size = UDim2.new(0, 15, 1, 0);
 					BackgroundTransparency = 1;
+					Position = UDim2.fromScale(0, 1);
+					Size = UDim2.new(0, 16, 1, 0);
 
 					Blend.New "Frame" {
 						Name = "container";
+						BackgroundTransparency = transparency;
 						Size = UDim2.fromScale(1, 1);
-						BorderColor3 = Color3.fromRGB(27, 42, 53);
 						ZIndex = 2;
+
+						Blend.New "UIStroke" {
+							Color = Color3.fromRGB(40, 40, 40);
+							Transparency = transparency;
+						};
 
 						Blend.New "UICorner" {
 							CornerRadius = UDim.new(0, 3);
@@ -327,7 +459,7 @@ function ColorPickerPane:Render(props)
 							Name = "cursor";
 							AnchorPoint = Vector2.new(0.5, 0.5);
 							BackgroundTransparency = transparency;
-							Size = UDim2.fromScale(1.5, 1);
+							Size = UDim2.fromScale(1.2, 1);
 
 							Position = Blend.Computed(percentHue, function(percent)
 								return UDim2.fromScale(0.5, percent)
@@ -356,6 +488,24 @@ function ColorPickerPane:Render(props)
 						TextColor3 = Color3.fromRGB(27, 42, 53);
 						TextSize = 8;
 						ZIndex = 5;
+
+						[Blend.Instance] = function(instance)
+							self._hue = instance
+						end;
+
+						[Blend.OnEvent "InputBegan"] = function(input)
+							if self:_isValidInput(input) then
+								self.DraggingHue = true
+								self:_updateHuePosition(input)
+							end
+						end;
+
+						[Blend.OnEvent "InputEnded"] = function(input)
+							if self:_isValidInput(input) then
+								self.DraggingHue = false
+								self.ColorUpdated:Fire(self.CurrentColor.Value)
+							end
+						end;
 					};
 				};
 
@@ -363,14 +513,19 @@ function ColorPickerPane:Render(props)
 					Name = "brightness";
 					Position = UDim2.fromScale(1, 1);
 					AnchorPoint = Vector2.new(1, 1);
-					Size = UDim2.new(0, 15, 1, 0);
+					Size = UDim2.new(0, 16, 1, 0);
 					BackgroundTransparency = 1;
 
 					Blend.New "Frame" {
 						Name = "container";
+						BackgroundTransparency = transparency;
 						Size = UDim2.fromScale(1, 1);
-						BorderColor3 = Color3.fromRGB(27, 42, 53);
 						ZIndex = 2;
+
+						Blend.New "UIStroke" {
+							Color = Color3.fromRGB(40, 40, 40);
+							Transparency = transparency;
+						};
 
 						Blend.New "UICorner" {
 							CornerRadius = UDim.new(0, 3);
@@ -386,9 +541,9 @@ function ColorPickerPane:Render(props)
 
 						Blend.New "Frame" {
 							Name = "cursor";
-							AnchorPoint = Vector2.new(0.5, 1);
+							AnchorPoint = Vector2.new(0.5, 0.5);
 							BackgroundTransparency = transparency;
-							Size = UDim2.fromScale(1.5, 1);
+							Size = UDim2.fromScale(1.2, 1);
 
 							Position = Blend.Computed(percentBrightness, function(percent)
 								return UDim2.fromScale(0.5, 1 - percent)
@@ -417,16 +572,35 @@ function ColorPickerPane:Render(props)
 						TextColor3 = Color3.fromRGB(27, 42, 53);
 						TextSize = 8;
 						ZIndex = 5;
+
+						[Blend.Instance] = function(instance)
+							self._brightness = instance
+						end;
+
+						[Blend.OnEvent "InputBegan"] = function(input)
+							if self:_isValidInput(input) then
+								self.DraggingBrightness = true
+								self:_updateBrightnessPosition(input)
+							end
+						end;
+
+						[Blend.OnEvent "InputEnded"] = function(input)
+							if self:_isValidInput(input) then
+								self.DraggingBrightness = false
+								self.ColorUpdated:Fire(self.CurrentColor.Value)
+							end
+						end;
 					};
 				};
 			};
 
 			Blend.New "Frame" {
 				Name = "inputs";
+				BackgroundTransparency = 1;
 				LayoutOrder = 4;
 				Position = UDim2.fromScale(0.780371, 0);
 				Size = UDim2.fromScale(0.2, 1);
-				BackgroundTransparency = 1;
+				ZIndex = 2;
 
 				Blend.New "UIListLayout" {
 					HorizontalAlignment = Enum.HorizontalAlignment.Center;
@@ -437,13 +611,18 @@ function ColorPickerPane:Render(props)
 
 				Blend.New "Frame" {
 					Name = "rgb";
+					BackgroundColor3 = Color3.fromRGB(15, 15, 15);
+					BackgroundTransparency = transparency;
 					LayoutOrder = 1;
 					Size = UDim2.fromScale(1, 1);
-					BackgroundColor3 = Color3.fromRGB(15, 15, 15);
-					BorderColor3 = Color3.fromRGB(27, 42, 53);
 
 					Blend.New "UICorner" {
 						CornerRadius = UDim.new(0, 5);
+					};
+
+					Blend.New "UIStroke" {
+						Color = Color3.fromRGB(40, 40, 40);
+						Transparency = transparency;
 					};
 
 					Blend.New "UIListLayout" {
@@ -502,6 +681,11 @@ function ColorPickerPane:Render(props)
 
 					Blend.New "UICorner" {
 						CornerRadius = UDim.new(0, 5);
+					};
+
+					Blend.New "UIStroke" {
+						Color = Color3.fromRGB(40, 40, 40);
+						Transparency = transparency;
 					};
 
 					Blend.New "UIListLayout" {
@@ -569,13 +753,18 @@ function ColorPickerPane:Render(props)
 
 					Blend.New "Frame" {
 						Name = "r";
+						BackgroundColor3 = Color3.fromRGB(15, 15, 15);
+						BackgroundTransparency = transparency;
 						LayoutOrder = 1;
 						Size = UDim2.fromScale(1, 1);
-						BackgroundColor3 = Color3.fromRGB(15, 15, 15);
-						BorderColor3 = Color3.fromRGB(27, 42, 53);
 
 						Blend.New "UICorner" {
 							CornerRadius = UDim.new(0, 5);
+						};
+
+						Blend.New "UIStroke" {
+							Color = Color3.fromRGB(40, 40, 40);
+							Transparency = transparency;
 						};
 
 						Blend.New "UIPadding" {
@@ -606,12 +795,18 @@ function ColorPickerPane:Render(props)
 
 					Blend.New "Frame" {
 						Name = "g";
+						BackgroundColor3 = Color3.fromRGB(15, 15, 15);
+						BackgroundTransparency = transparency;
 						LayoutOrder = 2;
 						Size = UDim2.fromScale(1, 1);
-						BackgroundColor3 = Color3.fromRGB(15, 15, 15);
-						BorderColor3 = Color3.fromRGB(27, 42, 53);
+
 						Blend.New "UICorner" {
 							CornerRadius = UDim.new(0, 5);
+						};
+
+						Blend.New "UIStroke" {
+							Color = Color3.fromRGB(40, 40, 40);
+							Transparency = transparency;
 						};
 
 						Blend.New "UIPadding" {
@@ -642,13 +837,18 @@ function ColorPickerPane:Render(props)
 
 					Blend.New "Frame" {
 						Name = "b";
+						BackgroundColor3 = Color3.fromRGB(15, 15, 15);
+						BackgroundTransparency = transparency;
 						LayoutOrder = 3;
 						Size = UDim2.fromScale(1, 1);
-						BackgroundColor3 = Color3.fromRGB(15, 15, 15);
-						BorderColor3 = Color3.fromRGB(27, 42, 53);
 
 						Blend.New "UICorner" {
 							CornerRadius = UDim.new(0, 5);
+						};
+
+						Blend.New "UIStroke" {
+							Color = Color3.fromRGB(40, 40, 40);
+							Transparency = transparency;
 						};
 
 						Blend.New "UIPadding" {
@@ -679,7 +879,21 @@ function ColorPickerPane:Render(props)
 				};
 			};
 		};
+
+		Blend.New "Frame" {
+			Name = "divider";
+			AnchorPoint = Vector2.new(0, 1);
+			BackgroundColor3 = Color3.fromRGB(35, 35, 35);
+			BackgroundTransparency = transparency;
+			Position = UDim2.new(0, 0, 1, -4);
+			Size = UDim2.new(1, 0, 0, 1);
+			ZIndex = 0;
+		};
 	};
+end
+
+function ColorPickerPane:_isValidInput(inputObject)
+	return inputObject.UserInputType == Enum.UserInputType.MouseButton1 or inputObject.UserInputType == Enum.UserInputType.Touch
 end
 
 return ColorPickerPane

--- a/src/StudioMacros/modules/Shared/CommandPalette/Input/Color/ColorPickerPane.luau
+++ b/src/StudioMacros/modules/Shared/CommandPalette/Input/Color/ColorPickerPane.luau
@@ -1,0 +1,685 @@
+local require = require(script.Parent.loader).load(script)
+
+local TweenService = game:GetService("TweenService")
+
+local BasicPane = require("BasicPane")
+local Blend = require("Blend")
+local Rx = require("Rx")
+local ValueObject = require("ValueObject")
+
+local TWEEN_INFO = TweenInfo.new(0.2, Enum.EasingStyle.Quart, Enum.EasingDirection.Out)
+
+local ColorPickerPane = setmetatable({}, BasicPane)
+ColorPickerPane.ClassName = "ColorPickerPane"
+ColorPickerPane.CustomResultType = "Color"
+ColorPickerPane.__index = ColorPickerPane
+
+function ColorPickerPane.new()
+	local self = setmetatable(BasicPane.new(), ColorPickerPane)
+
+	self._currentColor = self._maid:Add(ValueObject.new(Color3.new(1, 1, 1)))
+	self._percentVisibleTarget = self._maid:Add(ValueObject.new(0))
+	self._yPosition = self._maid:Add(ValueObject.new(0))
+
+	self._maid:GiveTask(self.VisibleChanged:Connect(function(isVisible)
+		self._percentVisibleTarget.Value = isVisible and 1 or 0
+	end))
+
+	return self
+end
+
+function ColorPickerPane:SetColor(color)
+	return self._currentColor:Mount(color)
+end
+
+function ColorPickerPane:GetYPosition()
+	return self._yPosition.Value
+end
+
+function ColorPickerPane:Render(props)
+	local target = self._percentVisibleTarget:Observe()
+
+	local percentVisible = Blend.Spring(target, 30, 0.7)
+	local transparency = props.Transparency
+
+	local hue = self._maid:Add(Blend.State(0))
+	local saturation = self._maid:Add(Blend.State(0))
+	local brightness = self._maid:Add(Blend.State(0))
+
+	self._maid:GiveTask(self._currentColor:Observe():Subscribe(function(color)
+		local h, s, v = color:ToHSV()
+
+		hue.Value = h
+		saturation.Value = s
+		brightness.Value = v
+	end))
+
+	local percentHue = Blend.Spring(hue, 35, 0.9)
+	local percentSaturation = Blend.Spring(saturation, 35, 0.9)
+	local percentBrightness = Blend.Spring(brightness, 35, 0.9)
+
+	local pickerCursorX = Blend.Spring(percentSaturation:Pipe({
+		Rx.map(function(percent)
+			return math.abs(percent - 1)
+		end);
+	}), 35, 0.7)
+
+	local pickerCursorY = Blend.Spring(percentBrightness:Pipe({
+		Rx.map(function(percent)
+			return math.abs(percent - 1)
+		end);
+	}), 35, 0.7)
+
+	local oldColor = self._maid:Add(Blend.State(self._currentColor.Value))
+	local targetColor = self._maid:Add(Instance.new("Color3Value"))
+
+	self._maid:GiveTask(self._currentColor:Observe():Subscribe(function(newColor)
+		TweenService:Create(targetColor, TWEEN_INFO, {
+			Value = newColor
+		}):Play()
+
+		oldColor.Value = newColor
+	end))
+
+	return Blend.New "Frame" {
+		Name = "ColorPickerPane";
+		BackgroundTransparency = 1;
+		LayoutOrder = -1;
+		LayoutOrder = -9e9;
+		Size = UDim2.new(1, 0, 0, 160);
+		Parent = props.TargetParent;
+
+		Visible = Blend.Computed(props.CustomResult, props.Enabled, function(customResult, isEnabled)
+			if customResult then
+				return isEnabled
+			else
+				return false
+			end
+		end);
+
+		[Blend.OnChange "AbsolutePosition"] = function(position)
+			if not self:IsVisible() then
+				return
+			end
+
+			self._yPosition.Value = math.round(position.Y)
+		end;
+
+		Blend.New "Frame" {
+			Name = "wrapper";
+			BackgroundTransparency = 1;
+			Size = UDim2.new(1, 0, 1, -10);
+
+			Blend.New "UIListLayout" {
+				FillDirection = Enum.FillDirection.Horizontal;
+				HorizontalAlignment = Enum.HorizontalAlignment.Center;
+				HorizontalFlex = Enum.UIFlexAlignment.Fill;
+				Padding = UDim.new(0, 10);
+				VerticalAlignment = Enum.VerticalAlignment.Center;
+			};
+
+			Blend.New "Frame" {
+				Name = "currentColor";
+				BackgroundColor3 = targetColor;
+				BackgroundTransparency = transparency;
+				LayoutOrder = 1;
+				Size = UDim2.new(0, 40, 1, 0);
+
+				Blend.New "UIFlexItem" { };
+
+				Blend.New "UICorner" {
+					CornerRadius = UDim.new(0, 5);
+				};
+			};
+
+			Blend.New "Frame" {
+				Name = "selection";
+				BackgroundTransparency = 1;
+				LayoutOrder = 2;
+				Size = UDim2.fromScale(0.5, 1);
+
+				Blend.New "Frame" {
+					Name = "background";
+					BackgroundTransparency = 1;
+					Size = UDim2.fromScale(1, 1);
+
+					Blend.New "Frame" {
+						Name = "white";
+						BackgroundTransparency = transparency;
+						Size = UDim2.fromScale(1, 1);
+						ZIndex = 2;
+
+						Blend.New "UIGradient" {
+							Transparency = NumberSequence.new(1, 0);
+						};
+
+						Blend.New "UICorner" {
+							CornerRadius = UDim.new(0, 5);
+						};
+					};
+
+					Blend.New "Frame" {
+						Name = "black";
+						BackgroundTransparency = transparency;
+						Size = UDim2.fromScale(1, 1);
+						ZIndex = 3;
+
+						Blend.New "UIGradient" {
+							Color = ColorSequence.new(Color3.fromRGB(0, 0, 0), Color3.fromRGB(0, 0, 0));
+							Rotation = 90;
+							Transparency = NumberSequence.new(1, 0);
+						};
+
+						Blend.New "UICorner" {
+							CornerRadius = UDim.new(0, 4);
+						};
+					};
+
+					Blend.New "Frame" {
+						Name = "color";
+						BackgroundColor3 = targetColor;
+						BackgroundTransparency = props.Transparency;
+						Size = UDim2.fromScale(1, 1);
+
+						Blend.New "UICorner" {
+							CornerRadius = UDim.new(0, 5);
+						};
+					};
+				};
+
+				Blend.New "TextButton" {
+					Name = "button";
+					Size = UDim2.fromScale(1, 1);
+					BackgroundColor3 = Color3.fromRGB(163, 162, 165);
+					BackgroundTransparency = 1;
+					TextColor3 = Color3.fromRGB(27, 42, 53);
+					TextSize = 8;
+					ZIndex = 5;
+				};
+
+				Blend.New "Frame" {
+					Name = "cursor";
+					AnchorPoint = Vector2.new(0.5, 0.5);
+					BackgroundTransparency = 1;
+					Size = UDim2.fromScale(0.1, 0.1);
+					ZIndex = 5;
+
+					Position = Blend.Computed(pickerCursorX, pickerCursorY, function(x, y)
+						return UDim2.fromScale(x, y);
+					end);
+
+					Blend.New "UIAspectRatioConstraint" {
+						AspectRatio = 1;
+					};
+
+					Blend.New "UISizeConstraint" {
+						MaxSize = Vector2.new(16, 16);
+					};
+
+					Blend.New "Frame" {
+						Position = UDim2.fromScale(0.5, 0.5);
+						AnchorPoint = Vector2.new(0.5, 0.5);
+						Size = UDim2.fromScale(1, 1);
+						BackgroundTransparency = 1;
+
+						Blend.New "Frame" {
+							Position = UDim2.fromScale(0.5, 0.5);
+							AnchorPoint = Vector2.new(0.5, 0.5);
+							Size = UDim2.fromScale(1, 1);
+							BackgroundTransparency = 1;
+
+							Blend.New "UICorner" {
+								CornerRadius = UDim.new(1, 0);
+							};
+
+							Blend.New "UIPadding" {
+								PaddingBottom = UDim.new(0, 2);
+								PaddingLeft = UDim.new(0, 2);
+								PaddingRight = UDim.new(0, 2);
+								PaddingTop = UDim.new(0, 2);
+							};
+
+							Blend.New "UIStroke" {
+								Color = Color3.fromRGB(255, 255, 255);
+								Transparency = transparency;
+							};
+
+							Blend.New "Frame" {
+								Position = UDim2.fromScale(0.5, 0.5);
+								AnchorPoint = Vector2.new(0.5, 0.5);
+								Size = UDim2.fromScale(1, 1);
+								BorderColor3 = Color3.fromRGB(27, 42, 53);
+
+								Blend.New "UICorner" {
+									CornerRadius = UDim.new(1, 0);
+								};
+							};
+						};
+
+						Blend.New "ImageLabel" {
+							Name = "shadow";
+							Position = UDim2.fromScale(0.5, 0.5);
+							AnchorPoint = Vector2.new(0.5, 0.5);
+							Size = UDim2.fromScale(2, 2);
+							BackgroundColor3 = Color3.fromRGB(163, 162, 165);
+							BackgroundTransparency = 1;
+							Image = "rbxassetid://6150493168";
+							ImageColor3 = Color3.fromRGB(0, 0, 0);
+							ImageTransparency = 0.8;
+							ZIndex = -10;
+						};
+					};
+				};
+			};
+
+			Blend.New "Frame" {
+				Name = "sliders";
+				LayoutOrder = 3;
+				Position = UDim2.fromScale(0.5, 0);
+				Size = UDim2.new(0, 40, 1, 0);
+				BackgroundTransparency = 1;
+
+				Blend.New "UIFlexItem" { };
+
+				Blend.New "Frame" {
+					Name = "hue";
+					Position = UDim2.fromScale(0, 1);
+					AnchorPoint = Vector2.new(0, 1);
+					Size = UDim2.new(0, 15, 1, 0);
+					BackgroundTransparency = 1;
+
+					Blend.New "Frame" {
+						Name = "container";
+						Size = UDim2.fromScale(1, 1);
+						BorderColor3 = Color3.fromRGB(27, 42, 53);
+						ZIndex = 2;
+
+						Blend.New "UICorner" {
+							CornerRadius = UDim.new(0, 3);
+						};
+
+						Blend.New "UIGradient" {
+							Color = ColorSequence.new({
+								ColorSequenceKeypoint.new(0, Color3.fromRGB(255, 0, 0)),
+								ColorSequenceKeypoint.new(0.05571, Color3.fromRGB(255, 85, 0)),
+								ColorSequenceKeypoint.new(0.111421, Color3.fromRGB(255, 170, 0)),
+								ColorSequenceKeypoint.new(0.167131, Color3.fromRGB(254, 255, 0)),
+								ColorSequenceKeypoint.new(0.222841, Color3.fromRGB(169, 255, 0)),
+								ColorSequenceKeypoint.new(0.278552, Color3.fromRGB(83, 255, 0)),
+								ColorSequenceKeypoint.new(0.334262, Color3.fromRGB(0, 255, 1)),
+								ColorSequenceKeypoint.new(0.389972, Color3.fromRGB(0, 255, 86)),
+								ColorSequenceKeypoint.new(0.445682, Color3.fromRGB(0, 255, 171)),
+								ColorSequenceKeypoint.new(0.501393, Color3.fromRGB(0, 252, 255)),
+								ColorSequenceKeypoint.new(0.557103, Color3.fromRGB(0, 167, 255)),
+								ColorSequenceKeypoint.new(0.612813, Color3.fromRGB(0, 82, 255)),
+								ColorSequenceKeypoint.new(0.668524, Color3.fromRGB(2, 0, 255)),
+								ColorSequenceKeypoint.new(0.724234, Color3.fromRGB(88, 0, 255)),
+								ColorSequenceKeypoint.new(0.779944, Color3.fromRGB(173, 0, 255)),
+								ColorSequenceKeypoint.new(0.835655, Color3.fromRGB(255, 0, 251)),
+								ColorSequenceKeypoint.new(0.891365, Color3.fromRGB(255, 0, 166)),
+								ColorSequenceKeypoint.new(0.947075, Color3.fromRGB(255, 0, 80)),
+								ColorSequenceKeypoint.new(1, Color3.fromRGB(255, 0, 0))
+							});
+							Rotation = 90;
+						};
+
+						Blend.New "Frame" {
+							Name = "cursor";
+							AnchorPoint = Vector2.new(0.5, 0.5);
+							BackgroundTransparency = transparency;
+							Size = UDim2.fromScale(1.5, 1);
+
+							Position = Blend.Computed(percentHue, function(percent)
+								return UDim2.fromScale(0.5, percent)
+							end);
+
+							Blend.New "UIAspectRatioConstraint" {
+								AspectRatio = 2.5;
+							};
+
+							Blend.New "UICorner" {
+								CornerRadius = UDim.new(0, 2);
+							};
+
+							Blend.New "UIStroke" {
+								Color = Color3.fromRGB(230, 230, 230);
+								Transparency = transparency;
+							};
+						};
+					};
+
+					Blend.New "TextButton" {
+						Name = "button";
+						Size = UDim2.fromScale(1, 1);
+						BackgroundColor3 = Color3.fromRGB(163, 162, 165);
+						BackgroundTransparency = 1;
+						TextColor3 = Color3.fromRGB(27, 42, 53);
+						TextSize = 8;
+						ZIndex = 5;
+					};
+				};
+
+				Blend.New "Frame" {
+					Name = "brightness";
+					Position = UDim2.fromScale(1, 1);
+					AnchorPoint = Vector2.new(1, 1);
+					Size = UDim2.new(0, 15, 1, 0);
+					BackgroundTransparency = 1;
+
+					Blend.New "Frame" {
+						Name = "container";
+						Size = UDim2.fromScale(1, 1);
+						BorderColor3 = Color3.fromRGB(27, 42, 53);
+						ZIndex = 2;
+
+						Blend.New "UICorner" {
+							CornerRadius = UDim.new(0, 3);
+						};
+
+						Blend.New "UIGradient" {
+							Rotation = 90;
+
+							Color = Blend.Computed(targetColor, function(color)
+								return ColorSequence.new(color, Color3.fromRGB(0, 0, 0));
+							end);
+						};
+
+						Blend.New "Frame" {
+							Name = "cursor";
+							AnchorPoint = Vector2.new(0.5, 1);
+							BackgroundTransparency = transparency;
+							Size = UDim2.fromScale(1.5, 1);
+
+							Position = Blend.Computed(percentBrightness, function(percent)
+								return UDim2.fromScale(0.5, 1 - percent)
+							end);
+
+							Blend.New "UIAspectRatioConstraint" {
+								AspectRatio = 2.5;
+							};
+
+							Blend.New "UICorner" {
+								CornerRadius = UDim.new(0, 2);
+							};
+
+							Blend.New "UIStroke" {
+								Color = Color3.fromRGB(230, 230, 230);
+								Transparency = transparency;
+							};
+						};
+					};
+
+					Blend.New "TextButton" {
+						Name = "button";
+						Size = UDim2.fromScale(1, 1);
+						BackgroundColor3 = Color3.fromRGB(163, 162, 165);
+						BackgroundTransparency = 1;
+						TextColor3 = Color3.fromRGB(27, 42, 53);
+						TextSize = 8;
+						ZIndex = 5;
+					};
+				};
+			};
+
+			Blend.New "Frame" {
+				Name = "inputs";
+				LayoutOrder = 4;
+				Position = UDim2.fromScale(0.780371, 0);
+				Size = UDim2.fromScale(0.2, 1);
+				BackgroundTransparency = 1;
+
+				Blend.New "UIListLayout" {
+					HorizontalAlignment = Enum.HorizontalAlignment.Center;
+					Padding = UDim.new(0, 5);
+					VerticalAlignment = Enum.VerticalAlignment.Center;
+					VerticalFlex = Enum.UIFlexAlignment.Fill;
+				};
+
+				Blend.New "Frame" {
+					Name = "rgb";
+					LayoutOrder = 1;
+					Size = UDim2.fromScale(1, 1);
+					BackgroundColor3 = Color3.fromRGB(15, 15, 15);
+					BorderColor3 = Color3.fromRGB(27, 42, 53);
+
+					Blend.New "UICorner" {
+						CornerRadius = UDim.new(0, 5);
+					};
+
+					Blend.New "UIListLayout" {
+						FillDirection = Enum.FillDirection.Horizontal;
+						HorizontalAlignment = Enum.HorizontalAlignment.Center;
+						HorizontalFlex = Enum.UIFlexAlignment.Fill;
+						Padding = UDim.new(0, 5);
+						VerticalAlignment = Enum.VerticalAlignment.Center;
+					};
+
+					Blend.New "UIPadding" {
+						PaddingBottom = UDim.new(0, 10);
+						PaddingLeft = UDim.new(0, 10);
+						PaddingRight = UDim.new(0, 10);
+						PaddingTop = UDim.new(0, 10);
+					};
+
+					Blend.New "ImageLabel" {
+						Name = "icon";
+						LayoutOrder = 1;
+						Size = UDim2.fromScale(1, 1);
+						BackgroundTransparency = 1;
+						Image = "rbxassetid://6034316009";
+						ImageColor3 = Color3.fromRGB(75, 75, 75);
+
+						Blend.New "UIAspectRatioConstraint" {
+							AspectRatio = 1;
+						};
+					};
+
+					Blend.New "TextBox" {
+						Name = "input";
+						LayoutOrder = 2;
+						Size = UDim2.fromScale(1, 1);
+						BackgroundColor3 = Color3.fromRGB(163, 162, 165);
+						BackgroundTransparency = 1;
+						FontFace = Font.new("rbxasset://fonts/families/RobotoMono.json", Enum.FontWeight.SemiBold, Enum.FontStyle.Normal);
+						PlaceholderColor3 = Color3.fromRGB(80, 80, 80);
+						TextColor3 = Color3.fromRGB(255, 255, 255);
+						TextSize = 18;
+						TextXAlignment = Enum.TextXAlignment.Left;
+						ZIndex = 5;
+
+						PlaceholderText = Blend.Computed(targetColor, function(color)
+							return `{math.round(color.R * 255)}, {math.round(color.G * 255)}, {math.round(color.B * 255)}`
+						end);
+					};
+				};
+
+				Blend.New "Frame" {
+					Name = "hex";
+					BackgroundColor3 = Color3.fromRGB(15, 15, 15);
+					BackgroundTransparency = transparency;
+					LayoutOrder = 2;
+					Size = UDim2.fromScale(1, 1);
+
+					Blend.New "UICorner" {
+						CornerRadius = UDim.new(0, 5);
+					};
+
+					Blend.New "UIListLayout" {
+						FillDirection = Enum.FillDirection.Horizontal;
+						HorizontalAlignment = Enum.HorizontalAlignment.Center;
+						HorizontalFlex = Enum.UIFlexAlignment.Fill;
+						Padding = UDim.new(0, 5);
+						VerticalAlignment = Enum.VerticalAlignment.Center;
+					};
+
+					Blend.New "UIPadding" {
+						PaddingBottom = UDim.new(0, 10);
+						PaddingLeft = UDim.new(0, 10);
+						PaddingRight = UDim.new(0, 10);
+						PaddingTop = UDim.new(0, 10);
+					};
+
+					Blend.New "ImageLabel" {
+						Name = "icon";
+						BackgroundTransparency = 1;
+						Image = "rbxassetid://6035078895";
+						ImageColor3 = Color3.fromRGB(75, 75, 75);
+						ImageTransparency = transparency;
+						LayoutOrder = 1;
+						Size = UDim2.fromScale(1, 1);
+
+						Blend.New "UIAspectRatioConstraint" {
+							AspectRatio = 1;
+						};
+					};
+
+					Blend.New "TextBox" {
+						Name = "input";
+						BackgroundColor3 = Color3.fromRGB(163, 162, 165);
+						BackgroundTransparency = 1;
+						FontFace = Font.new("rbxasset://fonts/families/RobotoMono.json", Enum.FontWeight.SemiBold, Enum.FontStyle.Normal);
+						LayoutOrder = 2;
+						PlaceholderColor3 = Color3.fromRGB(80, 80, 80);
+						Size = UDim2.fromScale(1, 1);
+						TextColor3 = Color3.fromRGB(255, 255, 255);
+						TextSize = 18;
+						TextTransparency = transparency;
+						TextXAlignment = Enum.TextXAlignment.Left;
+						ZIndex = 5;
+
+						PlaceholderText = Blend.Computed(targetColor, function(color)
+							return color:ToHex()
+						end);
+					};
+				};
+
+				Blend.New "Frame" {
+					Name = "rgbValues";
+					LayoutOrder = 3;
+					Size = UDim2.fromScale(1, 1);
+					BackgroundTransparency = 1;
+
+					Blend.New "UIListLayout" {
+						FillDirection = Enum.FillDirection.Horizontal;
+						HorizontalAlignment = Enum.HorizontalAlignment.Center;
+						HorizontalFlex = Enum.UIFlexAlignment.Fill;
+						Padding = UDim.new(0, 5);
+						VerticalAlignment = Enum.VerticalAlignment.Center;
+					};
+
+					Blend.New "Frame" {
+						Name = "r";
+						LayoutOrder = 1;
+						Size = UDim2.fromScale(1, 1);
+						BackgroundColor3 = Color3.fromRGB(15, 15, 15);
+						BorderColor3 = Color3.fromRGB(27, 42, 53);
+
+						Blend.New "UICorner" {
+							CornerRadius = UDim.new(0, 5);
+						};
+
+						Blend.New "UIPadding" {
+							PaddingBottom = UDim.new(0, 10);
+							PaddingLeft = UDim.new(0, 10);
+							PaddingRight = UDim.new(0, 10);
+							PaddingTop = UDim.new(0, 10);
+						};
+
+						Blend.New "TextBox" {
+							Name = "input";
+							BackgroundColor3 = Color3.fromRGB(163, 162, 165);
+							BackgroundTransparency = 1;
+							FontFace = Font.new("rbxasset://fonts/families/RobotoMono.json", Enum.FontWeight.SemiBold, Enum.FontStyle.Normal);
+							LayoutOrder = 2;
+							PlaceholderColor3 = Color3.fromRGB(80, 80, 80);
+							Size = UDim2.fromScale(1, 1);
+							TextColor3 = Color3.fromRGB(255, 255, 255);
+							TextSize = 18;
+							TextTransparency = transparency;
+							ZIndex = 5;
+
+							PlaceholderText = Blend.Computed(targetColor, function(color)
+								return `{math.round(color.R * 255)}`
+							end);
+						};
+					};
+
+					Blend.New "Frame" {
+						Name = "g";
+						LayoutOrder = 2;
+						Size = UDim2.fromScale(1, 1);
+						BackgroundColor3 = Color3.fromRGB(15, 15, 15);
+						BorderColor3 = Color3.fromRGB(27, 42, 53);
+						Blend.New "UICorner" {
+							CornerRadius = UDim.new(0, 5);
+						};
+
+						Blend.New "UIPadding" {
+							PaddingBottom = UDim.new(0, 10);
+							PaddingLeft = UDim.new(0, 10);
+							PaddingRight = UDim.new(0, 10);
+							PaddingTop = UDim.new(0, 10);
+						};
+
+						Blend.New "TextBox" {
+							Name = "input";
+							BackgroundColor3 = Color3.fromRGB(163, 162, 165);
+							BackgroundTransparency = 1;
+							FontFace = Font.new("rbxasset://fonts/families/RobotoMono.json", Enum.FontWeight.SemiBold, Enum.FontStyle.Normal);
+							LayoutOrder = 2;
+							PlaceholderColor3 = Color3.fromRGB(80, 80, 80);
+							Size = UDim2.fromScale(1, 1);
+							TextColor3 = Color3.fromRGB(255, 255, 255);
+							TextSize = 18;
+							TextTransparency = transparency;
+							ZIndex = 5;
+
+							PlaceholderText = Blend.Computed(targetColor, function(color)
+								return `{math.round(color.G * 255)}`
+							end);
+						};
+					};
+
+					Blend.New "Frame" {
+						Name = "b";
+						LayoutOrder = 3;
+						Size = UDim2.fromScale(1, 1);
+						BackgroundColor3 = Color3.fromRGB(15, 15, 15);
+						BorderColor3 = Color3.fromRGB(27, 42, 53);
+
+						Blend.New "UICorner" {
+							CornerRadius = UDim.new(0, 5);
+						};
+
+						Blend.New "UIPadding" {
+							PaddingBottom = UDim.new(0, 10);
+							PaddingLeft = UDim.new(0, 10);
+							PaddingRight = UDim.new(0, 10);
+							PaddingTop = UDim.new(0, 10);
+						};
+
+						Blend.New "TextBox" {
+							Name = "input";
+							BackgroundColor3 = Color3.fromRGB(163, 162, 165);
+							BackgroundTransparency = 1;
+							FontFace = Font.new("rbxasset://fonts/families/RobotoMono.json", Enum.FontWeight.SemiBold, Enum.FontStyle.Normal);
+							LayoutOrder = 2;
+							PlaceholderColor3 = Color3.fromRGB(80, 80, 80);
+							Size = UDim2.fromScale(1, 1);
+							TextColor3 = Color3.fromRGB(255, 255, 255);
+							TextSize = 18;
+							TextTransparency = transparency;
+							ZIndex = 5;
+
+							PlaceholderText = Blend.Computed(targetColor, function(color)
+								return `{math.round(color.B * 255)}`
+							end);
+						};
+					};
+				};
+			};
+		};
+	};
+end
+
+return ColorPickerPane

--- a/src/StudioMacros/modules/Shared/CommandPalette/Input/Font/FontEntry.luau
+++ b/src/StudioMacros/modules/Shared/CommandPalette/Input/Font/FontEntry.luau
@@ -1,0 +1,273 @@
+local require = require(script.Parent.loader).load(script)
+
+local BasicPane = require("BasicPane")
+local Blend = require("Blend")
+local ButtonHighlightModel = require("ButtonHighlightModel")
+local Fzy = require("Fzy")
+local SearchUtils = require("SearchUtils")
+local Signal = require("Signal")
+local ValueObject = require("ValueObject")
+
+local FontEntry = setmetatable({}, BasicPane)
+FontEntry.ClassName = "FontEntry"
+FontEntry.CustomResultType = "Font"
+FontEntry.__index = FontEntry
+
+function FontEntry.new()
+	local self = setmetatable(BasicPane.new(), FontEntry)
+
+	self._defaultIndex = self._maid:Add(ValueObject.new(0))
+	self._fontName = self._maid:Add(ValueObject.new(""))
+	self._model = self._maid:Add(ButtonHighlightModel.new())
+	self._percentVisibleTarget = self._maid:Add(ValueObject.new(0))
+	self._percentVisibleTarget = self._maid:Add(ValueObject.new(0))
+	self._styleCount = self._maid:Add(ValueObject.new(0))
+	self._yPosition = self._maid:Add(ValueObject.new(0))
+
+	self.Activated = self._maid:Add(Signal.new())
+	self.Font = self._maid:Add(ValueObject.new(nil))
+	self.SearchScore = self._maid:Add(ValueObject.new(0))
+
+	self._maid:GiveTask(self.VisibleChanged:Connect(function(isVisible)
+		self._percentVisibleTarget.Value = isVisible and 1 or 0
+	end))
+
+	return self
+end
+
+function FontEntry:SetFontName(fontName: string)
+	self._fontName.Value = fontName
+end
+
+function FontEntry:SetStyleCount(count: number)
+	self._styleCount.Value = count
+end
+
+function FontEntry:GetYPosition()
+	return self._yPosition.Value
+end
+
+function FontEntry:SetDefaultIndex(index: number)
+	self._defaultIndex.Value = index
+end
+
+function FontEntry:SetIsSelected(isSelected: boolean)
+	self._model:SetIsChoosen(isSelected)
+	self._model._isMouseOver.Value = isSelected
+end
+
+function FontEntry:GetData()
+	return self.Font.Value
+end
+
+function FontEntry:GetFontName()
+	return self._fontName.Value
+end
+
+function FontEntry:Render(props)
+	local target = self._percentVisibleTarget:Observe()
+
+	local percentHighlighted = Blend.Spring(self._model:ObservePercentHighlightedTarget(), 35, 0.7)
+	local percentPressed = Blend.Spring(self._model:ObservePercentPressedTarget(), 35, 0.55)
+	local percentSelected = Blend.AccelTween(self._model:ObservePercentChoosenTarget(), 400)
+
+	local foregroundColor = Blend.Computed(percentSelected, function(percent)
+		return Color3.fromRGB(150, 150, 150):Lerp(Color3.fromRGB(255, 255, 255), percent)
+	end);
+
+	local fzyConfig = props.FzyConfig
+	local transparency = props.Transparency
+
+	self._maid:GiveTask(Blend.Computed(self._fontName, props.SearchQuery, function(fontName, searchQuery)
+		if searchQuery == "" then
+			self.SearchScore.Value = nil
+			return
+		end
+
+		self.SearchScore.Value = Fzy.score(fzyConfig, searchQuery, string.lower(fontName))
+	end):Subscribe())
+
+	return Blend.New "Frame" {
+		Name = "FontEntry";
+		BackgroundTransparency = 1;
+		Parent = props.TargetParent;
+
+		LayoutOrder = Blend.Computed(self.SearchScore, self._defaultIndex, function(score, defaultIndex)
+			return score and -(score * 10000) or defaultIndex
+		end);
+
+		Size = Blend.Computed(props.EntryHeight, function(height)
+			if height == 45 then
+				return UDim2.new(1, 0, 0, 60)
+			else
+				return UDim2.new(1, 0, 0, 40)
+			end
+		end);
+
+		Visible = Blend.Computed(props.CustomResult, props.Enabled, props.SearchQuery, self.SearchScore, function(customResult, isEnabled, searchQuery, searchScore)
+			if not customResult then
+				return false
+			elseif isEnabled then
+				if searchQuery ~= "" and searchScore then
+					return searchScore > 0
+				else
+					return true
+				end
+			end
+
+			return false
+		end);
+
+		ZIndex = Blend.Computed(self.SearchScore, self._defaultIndex, function(score, defaultIndex)
+			return score and -(score * 10000) or defaultIndex
+		end);
+
+		[Blend.OnChange "AbsolutePosition"] = function(position)
+			if not self:IsVisible() then
+				return
+			end
+
+			self._yPosition.Value = math.round(position.Y)
+		end;
+
+		Blend.New "Frame" {
+			Name = "wrapper";
+			BackgroundColor3 = Color3.fromRGB(50, 50, 50);
+			Size = UDim2.fromScale(1, 1);
+
+			BackgroundTransparency = Blend.Computed(transparency, percentHighlighted, function(percent, percentHighlight)
+				return 1 - percentHighlight + percent
+			end);
+
+			Blend.New "UIPadding" {
+				PaddingBottom = UDim.new(0, 14);
+				PaddingLeft = UDim.new(0, 7);
+				PaddingRight = UDim.new(0, 7);
+				PaddingTop = UDim.new(0, 14);
+			};
+
+			Blend.New "UIStroke" {
+				Color = Color3.fromRGB(85, 85, 85);
+				Transparency = Blend.Computed(transparency, percentHighlighted, function(percent, percentHighlight)
+					return math.clamp(1 - percentHighlight + percent, 0, 1)
+				end);
+			};
+
+			Blend.New "UICorner" {
+				CornerRadius = UDim.new(0, 5);
+			};
+
+			Blend.New "TextLabel" {
+				Name = "styles";
+				LayoutOrder = 2;
+				Position = UDim2.fromScale(1, 0.5);
+				AnchorPoint = Vector2.new(1, 0.5);
+				Size = UDim2.new(1, 0, 0, 15);
+				BackgroundTransparency = 1;
+				FontFace = Font.new("rbxasset://fonts/families/SourceSansPro.json");
+				TextColor3 = Color3.fromRGB(85, 85, 85);
+				TextWrapped = true;
+				TextXAlignment = Enum.TextXAlignment.Right;
+
+				Text = Blend.Computed(self._styleCount, function(count)
+					return `{count} {count == 1 and "style" or "styles"}`
+				end);
+			};
+
+			Blend.New "Frame" {
+				Name = "container";
+				LayoutOrder = 9;
+				Size = UDim2.fromScale(0.9, 1);
+				BackgroundTransparency = 1;
+
+				Blend.New "UIListLayout" {
+					HorizontalAlignment = Enum.HorizontalAlignment.Center;
+					VerticalAlignment = Enum.VerticalAlignment.Center;
+				};
+
+				Blend.New "TextLabel" {
+					Name = "textPreview";
+					LayoutOrder = 2;
+					Position = UDim2.fromScale(0, 0.5);
+					AnchorPoint = Vector2.new(0, 0.5);
+					Size = UDim2.new(1, 0, 0, 20);
+					BackgroundTransparency = 1;
+					RichText = true;
+					TextColor3 = Color3.fromRGB(255, 255, 255);
+					TextSize = 20;
+					TextTruncate = Enum.TextTruncate.AtEnd;
+					TextXAlignment = Enum.TextXAlignment.Left;
+
+					Text = Blend.Computed(props.EntryHeight, props.FontPreviewText, self._fontName, props.SearchQuery, function(height, fontPreviewText, fontName, searchQuery)
+						if height == 45 then
+							return SearchUtils.getMatchedString(fzyConfig, fontPreviewText, searchQuery)
+						else
+							return SearchUtils.getMatchedString(fzyConfig, fontName, searchQuery)
+						end
+					end);
+
+					FontFace = Blend.Computed(self.Font, function(font)
+						if not font then
+							return Font.new("rbxasset://fonts/families/SourceSansPro.json")
+						end
+
+						return font
+					end);
+				};
+
+				Blend.New "TextLabel" {
+					Name = "fontName";
+					AnchorPoint = Vector2.new(1, 0.5);
+					BackgroundTransparency = 1;
+					FontFace = Font.new("rbxasset://fonts/families/SourceSansPro.json");
+					LayoutOrder = 2;
+					Position = UDim2.fromScale(1, 0.5);
+					RichText = true;
+					Size = UDim2.new(1, 0, 0, 15);
+					TextColor3 = Color3.fromRGB(110, 110, 110);
+					TextWrapped = true;
+					TextXAlignment = Enum.TextXAlignment.Left;
+
+					Text = Blend.Computed(self._fontName, props.SearchQuery, function(fontName, searchQuery)
+						if searchQuery ~= "" then
+							return SearchUtils.getMatchedString(fzyConfig, fontName, searchQuery)
+						else
+							return fontName
+						end
+					end);
+
+					Visible = Blend.Computed(props.EntryHeight, function(height)
+						return height == 45
+					end);
+				};
+			};
+		};
+
+		Blend.New "Frame" {
+			Name = "divider";
+			AnchorPoint = Vector2.new(0, 1);
+			BackgroundColor3 = Color3.fromRGB(35, 35, 35);
+			BackgroundTransparency = transparency;
+			Position = UDim2.new(0, 0, 1, 2);
+			Size = UDim2.new(1, 0, 0, 1);
+		};
+
+		Blend.New "TextButton" {
+			Name = "button";
+			BackgroundTransparency = 1;
+			Size = UDim2.fromScale(1, 1);
+			Visible = props.Enabled;
+			ZIndex = 5;
+
+			[Blend.OnEvent "Activated"] = function()
+				self.Activated:Fire()
+			end;
+
+			[Blend.Instance] = function(button)
+				self._model:SetButton(button)
+			end;
+		};
+	}
+end
+
+return FontEntry

--- a/src/StudioMacros/modules/Shared/CommandPalette/Input/Font/FontStyleEntry.luau
+++ b/src/StudioMacros/modules/Shared/CommandPalette/Input/Font/FontStyleEntry.luau
@@ -1,0 +1,327 @@
+local require = require(script.Parent.loader).load(script)
+
+local BasicPane = require("BasicPane")
+local Blend = require("Blend")
+local ButtonHighlightModel = require("ButtonHighlightModel")
+local Fzy = require("Fzy")
+local SearchUtils = require("SearchUtils")
+local Signal = require("Signal")
+local String = require("String")
+local ValueObject = require("ValueObject")
+
+local FontStyleEntry = setmetatable({}, BasicPane)
+FontStyleEntry.ClassName = "FontStyleEntry"
+FontStyleEntry.CustomResultType = "FontStyle"
+FontStyleEntry.__index = FontStyleEntry
+
+function FontStyleEntry.new()
+	local self = setmetatable(BasicPane.new(), FontStyleEntry)
+
+	self._compatibleFonts = {}
+
+	self._defaultIndex = self._maid:Add(ValueObject.new(0))
+	self._enumWeight = self._maid:Add(ValueObject.new(nil))
+	self._fontStyleName = self._maid:Add(ValueObject.new(""))
+	self._fontWeight = self._maid:Add(ValueObject.new(nil))
+	self._fontWeightName = self._maid:Add(ValueObject.new(""))
+	self._isItalic = self._maid:Add(ValueObject.new(false))
+	self._model = self._maid:Add(ButtonHighlightModel.new())
+	self._percentVisibleTarget = self._maid:Add(ValueObject.new(0))
+	self._percentVisibleTarget = self._maid:Add(ValueObject.new(0))
+	self._styleCount = self._maid:Add(ValueObject.new(0))
+	self._yPosition = self._maid:Add(ValueObject.new(0))
+
+	self.Activated = self._maid:Add(Signal.new())
+	self.SearchScore = self._maid:Add(ValueObject.new(0))
+
+	self._maid:GiveTask(self.VisibleChanged:Connect(function(isVisible)
+		self._percentVisibleTarget.Value = isVisible and 1 or 0
+	end))
+
+	return self
+end
+
+function FontStyleEntry:SetFontCompatible(font: Font)
+	self._compatibleFonts[font.Family] = true
+end
+
+function FontStyleEntry:IsFontCompatible(font: Font)
+	return self._compatibleFonts[font.Family]
+end
+
+function FontStyleEntry:SetStyleName(styleName: string)
+	if not styleName then
+		return
+	end
+
+	self._fontStyleName.Value = styleName
+
+	local formattedName = String.toCamelCase(styleName)
+	local cleanStyleName = formattedName:gsub("Italic", "")
+
+	local weights = Enum.FontWeight:GetEnumItems()
+	local weightNames = {}
+	for _, weight in weights do
+		weightNames[weight.Name] = true
+	end
+
+	local isValidWeight = weightNames[cleanStyleName]
+	local weight
+
+	if not isValidWeight then
+		if formattedName == "Italic" then
+			weight = Enum.FontWeight.Regular
+			isValidWeight = true
+		elseif cleanStyleName == "Black" then
+			weight = Enum.FontWeight.Heavy
+			isValidWeight = true
+		end
+	end
+
+	if isValidWeight then
+		weight = weight or Enum.FontWeight[cleanStyleName]
+		self._fontWeight.Value = weight.Value
+		self._fontWeightName.Value = weight.Name
+		self._enumWeight.Value = weight
+	end
+end
+
+function FontStyleEntry:GetFontWeight()
+	return self._fontWeight.Value or 100
+end
+
+function FontStyleEntry:SetIsItalic(isItalic: boolean)
+	self._isItalic.Value = isItalic
+end
+
+function FontStyleEntry:SetStyleCount(count: number)
+	self._styleCount.Value = count
+end
+
+function FontStyleEntry:GetYPosition()
+	return self._yPosition.Value
+end
+
+function FontStyleEntry:SetDefaultIndex(index: number)
+	self._defaultIndex.Value = index
+end
+
+function FontStyleEntry:SetIsSelected(isSelected: boolean)
+	self._model:SetIsChoosen(isSelected)
+	self._model._isMouseOver.Value = isSelected
+end
+
+function FontStyleEntry:GetData()
+	return self._enumWeight.Value, self._isItalic.Value
+end
+
+function FontStyleEntry:Render(props)
+	local target = self._percentVisibleTarget:Observe()
+
+	local percentHighlighted = Blend.Spring(self._model:ObservePercentHighlightedTarget(), 35, 0.7)
+	local percentPressed = Blend.Spring(self._model:ObservePercentPressedTarget(), 35, 0.55)
+	local percentSelected = Blend.AccelTween(self._model:ObservePercentChoosenTarget(), 400)
+
+	local foregroundColor = Blend.Computed(percentSelected, function(percent)
+		return Color3.fromRGB(150, 150, 150):Lerp(Color3.fromRGB(255, 255, 255), percent)
+	end);
+
+	local fzyConfig = props.FzyConfig
+	local transparency = props.Transparency
+
+	self._maid:GiveTask(Blend.Computed(self._fontStyleName, self._fontWeightName, props.SearchQuery, function(styleName, weightName, searchQuery)
+		if searchQuery == "" then
+			self.SearchScore.Value = nil
+			return
+		end
+
+		self.SearchScore.Value = Fzy.score(fzyConfig, searchQuery, `{string.lower(styleName)} {string.lower(weightName)}`)
+	end):Subscribe())
+
+	return Blend.New "Frame" {
+		Name = "FontStyleEntry";
+		BackgroundTransparency = 1;
+		Parent = props.TargetParent;
+
+		LayoutOrder = Blend.Computed(self.SearchScore, self._defaultIndex, function(score, defaultIndex)
+			return score and -(score * 10000) or defaultIndex
+		end);
+
+		Size = Blend.Computed(props.EntryHeight, function(height)
+			if height == 45 then
+				return UDim2.new(1, 0, 0, 60)
+			else
+				return UDim2.new(1, 0, 0, 40)
+			end
+		end);
+
+		Visible = Blend.Computed(props.CustomResult, props.Enabled, props.SearchQuery, self.SearchScore, function(customResult, isEnabled, searchQuery, searchScore)
+			if not customResult then
+				return false
+			elseif isEnabled then
+				if searchQuery ~= "" and searchScore then
+					return searchScore > 0
+				else
+					return true
+				end
+			end
+
+			return false
+		end);
+
+		ZIndex = Blend.Computed(self.SearchScore, self._defaultIndex, function(score, defaultIndex)
+			return score and -(score * 10000) or defaultIndex
+		end);
+
+		[Blend.OnChange "AbsolutePosition"] = function(position)
+			if not self:IsVisible() then
+				return
+			end
+
+			self._yPosition.Value = math.round(position.Y)
+		end;
+
+		Blend.New "Frame" {
+			Name = "wrapper";
+			BackgroundColor3 = Color3.fromRGB(50, 50, 50);
+			Size = UDim2.fromScale(1, 1);
+
+			BackgroundTransparency = Blend.Computed(transparency, percentHighlighted, function(percent, percentHighlight)
+				return 1 - percentHighlight + percent
+			end);
+
+			Blend.New "UIPadding" {
+				PaddingBottom = UDim.new(0, 14);
+				PaddingLeft = UDim.new(0, 7);
+				PaddingRight = UDim.new(0, 7);
+				PaddingTop = UDim.new(0, 14);
+			};
+
+			Blend.New "UIStroke" {
+				Color = Color3.fromRGB(85, 85, 85);
+				Transparency = Blend.Computed(transparency, percentHighlighted, function(percent, percentHighlight)
+					return math.clamp(1 - percentHighlight + percent, 0, 1)
+				end);
+			};
+
+			Blend.New "UICorner" {
+				CornerRadius = UDim.new(0, 5);
+			};
+
+			Blend.New "TextLabel" {
+				Name = "styles";
+				LayoutOrder = 2;
+				Position = UDim2.fromScale(1, 0.5);
+				AnchorPoint = Vector2.new(1, 0.5);
+				Size = UDim2.new(1, 0, 0, 15);
+				BackgroundTransparency = 1;
+				FontFace = Font.new("rbxasset://fonts/families/SourceSansPro.json");
+				TextColor3 = Color3.fromRGB(85, 85, 85);
+				TextWrapped = true;
+				TextXAlignment = Enum.TextXAlignment.Right;
+
+				Text = Blend.Computed(self._fontWeight, function(weight)
+					return weight or ""
+				end);
+			};
+
+			Blend.New "Frame" {
+				Name = "container";
+				LayoutOrder = 9;
+				Size = UDim2.fromScale(0.9, 1);
+				BackgroundTransparency = 1;
+
+				Blend.New "UIListLayout" {
+					HorizontalAlignment = Enum.HorizontalAlignment.Center;
+					VerticalAlignment = Enum.VerticalAlignment.Center;
+				};
+
+				Blend.New "TextLabel" {
+					Name = "textPreview";
+					AnchorPoint = Vector2.new(0, 0.5);
+					BackgroundTransparency = 1;
+					LayoutOrder = 2;
+					Position = UDim2.fromScale(0, 0.5);
+					RichText = true;
+					Size = UDim2.new(1, 0, 0, 20);
+					TextColor3 = Color3.fromRGB(255, 255, 255);
+					TextSize = 20;
+					TextTruncate = Enum.TextTruncate.AtEnd;
+					TextXAlignment = Enum.TextXAlignment.Left;
+
+					FontFace = Blend.Computed(props.TargetFont, self._enumWeight, self._isItalic, function(font, fontWeight, isItalic)
+						if not font then
+							return Font.new("rbxasset://fonts/families/SourceSansPro.json")
+						end
+
+						local family = font.Family
+						local style = isItalic and Enum.FontStyle.Italic or Enum.FontStyle.Normal
+
+						return Font.new(family, fontWeight or Enum.FontWeight.Regular, style)
+					end);
+
+					Text = Blend.Computed(props.EntryHeight, self._fontStyleName, self._fontWeightName, props.SearchQuery, function(height, fontStyleName, fontWeightName, searchQuery)
+						if height == 45 then
+							return SearchUtils.getMatchedString(fzyConfig, fontStyleName, searchQuery)
+						else
+							return SearchUtils.getMatchedString(fzyConfig, fontWeightName, searchQuery)
+						end
+					end);
+				};
+
+				Blend.New "TextLabel" {
+					Name = "fontWeightName";
+					AnchorPoint = Vector2.new(1, 0.5);
+					BackgroundTransparency = 1;
+					FontFace = Font.new("rbxasset://fonts/families/SourceSansPro.json");
+					LayoutOrder = 2;
+					Position = UDim2.fromScale(1, 0.5);
+					RichText = true;
+					Size = UDim2.new(1, 0, 0, 15);
+					TextColor3 = Color3.fromRGB(110, 110, 110);
+					TextWrapped = true;
+					TextXAlignment = Enum.TextXAlignment.Left;
+
+					Text = Blend.Computed(self._fontWeightName, props.SearchQuery, function(fontWeightName, searchQuery)
+						if searchQuery ~= "" then
+							return SearchUtils.getMatchedString(fzyConfig, fontWeightName, searchQuery)
+						else
+							return fontWeightName
+						end
+					end);
+
+					Visible = Blend.Computed(props.EntryHeight, function(height)
+						return height == 45
+					end);
+				};
+			};
+		};
+
+		Blend.New "Frame" {
+			Name = "divider";
+			AnchorPoint = Vector2.new(0, 1);
+			BackgroundColor3 = Color3.fromRGB(35, 35, 35);
+			BackgroundTransparency = transparency;
+			Position = UDim2.new(0, 0, 1, 2);
+			Size = UDim2.new(1, 0, 0, 1);
+		};
+
+		Blend.New "TextButton" {
+			Name = "button";
+			BackgroundTransparency = 1;
+			Size = UDim2.fromScale(1, 1);
+			Visible = props.Enabled;
+			ZIndex = 5;
+
+			[Blend.OnEvent "Activated"] = function()
+				self.Activated:Fire()
+			end;
+
+			[Blend.Instance] = function(button)
+				self._model:SetButton(button)
+			end;
+		};
+	}
+end
+
+return FontStyleEntry

--- a/src/StudioMacros/modules/Shared/Fonts/FontData.luau
+++ b/src/StudioMacros/modules/Shared/Fonts/FontData.luau
@@ -1,0 +1,1159 @@
+return {
+	[12187364842] = {
+		Name = "Unica One";
+		Styles = { "Regular" };
+	};
+
+	[12187366475] = {
+		Name = "Rubik Maze";
+		Styles = { "Regular" };
+	};
+
+	[12187364147] = {
+		Name = "IBM Plex Sans JP";
+		Styles = {
+			"Thin",
+			"Extra Light",
+			"Light",
+			"Regular",
+			"Medium",
+			"Semi Bold",
+			"Bold"
+		};
+	};
+
+	[12187369639] = {
+		Name = "Noto Serif JP";
+		Styles = { "Extra Light", "Light", "Regular", "Medium", "Semi Bold", "Bold", "Black" };
+	};
+
+	[12187361943] = {
+		Name = "Parisienne";
+		Styles = { "Regular" };
+	};
+
+	[12187367666] = {
+		Name = "Bungee Shade";
+		Styles = { "Regular" };
+	};
+
+	[11702779240] = {
+		Name = "Raleway";
+		Styles = {
+			"Thin",
+			"Thin Italic",
+			"Extra Light",
+			"Extra Light Italic",
+			"Light",
+			"Light Italic",
+			"Regular",
+			"Italic",
+			"Medium",
+			"Medium Italic",
+			"Semi Bold",
+			"Semi Bold Italic",
+			"Bold",
+			"Bold Italic",
+			"Extra Bold",
+			"Extra Bold Italic",
+			"Black",
+			"Black Italic"
+		};
+	};
+
+	[11322590111] = {
+		Name = "Fuzzy Bubbles";
+		Styles = { "Regular", "Bold" };
+	};
+
+	[12187366846] = {
+		Name = "Noto Serif HK";
+		Styles = {
+			"Extra Light",
+			"Light",
+			"Regular",
+			"Medium",
+			"Semi Bold",
+			"Bold",
+			"Extra Bold",
+			"Black"
+		};
+	};
+
+	[12187363148] = {
+		Name = "Rubik Burned";
+		Styles = { "Regular" };
+	};
+
+	[12187371622] = {
+		Name = "Kings";
+		Styles = { "Regular" };
+	};
+
+	[12187363616] = {
+		Name = "Are You Serious";
+		Styles = { "Regular" };
+	};
+
+	[12187370000] = {
+		Name = "Bungee Inline";
+		Styles = { "Regular" };
+	};
+
+	[12187374537] = {
+		Name = "Sono";
+		Styles = {
+			"Extra Light",
+			"Light",
+			"Regular",
+			"Medium",
+			"Semi Bold",
+			"Bold",
+			"Extra Bold"
+		};
+	};
+
+	[12187375422] = {
+		Name = "Rajdhani";
+		Styles = {
+			"Light",
+			"Regular",
+			"Medium",
+			"Semi Bold",
+			"Bold"
+		};
+	};
+
+	[12187365977] = {
+		Name = "Rubik";
+		Styles = {
+			"Light",
+			"Light Italic",
+			"Regular",
+			"Italic",
+			"Medium",
+			"Medium Italic",
+			"Semi Bold",
+			"Semi Bold Italic",
+			"Bold",
+			"Bold Italic",
+			"Extra Bold",
+			"Extra Bold Italic",
+			"Black",
+			"Black Italic"
+		};
+	};
+
+	[12187367066] = {
+		Name = "Rubik Marker Hatch";
+		Styles = { "Regular" };
+	};
+
+	[12187607287] = {
+		Name = "Prompt";
+		Styles = {
+			"Thin",
+			"Thin Italic",
+			"Extra Light",
+			"Extra Light Italic",
+			"Light",
+			"Light Italic",
+			"Regular",
+			"Italic",
+			"Medium",
+			"Medium Italic",
+			"Semi Bold",
+			"Semi Bold Italic",
+			"Bold",
+			"Bold Italic",
+			"Extra Bold",
+			"Extra Bold Italic",
+			"Black",
+			"Black Italic"
+		};
+	};
+
+	[12187377588] = {
+		Name = "Tajawal";
+		Styles = {
+			"Extra Light",
+			"Light",
+			"Regular",
+			"Medium",
+			"Bold",
+			"Extra Bold",
+			"Black"
+		};
+	};
+
+	[12187361116] = {
+		Name = "Hind";
+		Styles = {
+			"Light",
+			"Regular",
+			"Medium",
+			"Semi Bold",
+			"Bold"
+		};
+	};
+
+	[12187370747] = {
+		Name = "Noto Sans";
+		Styles = {
+			"Thin",
+			"Thin Italic",
+			"Extra Light",
+			"Extra Light Italic",
+			"Light",
+			"Light Italic",
+			"Regular",
+			"Italic",
+			"Medium",
+			"Medium Italic",
+			"Semi Bold",
+			"Semi Bold Italic",
+			"Bold",
+			"Bold Italic",
+			"Extra Bold",
+			"Extra Bold Italic",
+			"Black",
+			"Black Italic"
+		};
+	};
+
+	[12187372847] = {
+		Name = "Barlow";
+		Styles = {
+			"Thin",
+			"Thin Italic",
+			"Extra Light",
+			"Extra Light Italic",
+			"Light",
+			"Light Italic",
+			"Regular",
+			"Italic",
+			"Medium",
+			"Medium Italic",
+			"Semi Bold",
+			"Semi Bold Italic",
+			"Bold",
+			"Bold Italic",
+			"Extra Bold",
+			"Extra Bold Italic",
+			"Black",
+			"Black Italic"
+		};
+	};
+
+	[12187368625] = {
+		Name = "Roboto Slab";
+		Styles = {
+			"Thin",
+			"Extra Light",
+			"Light",
+			"Regular",
+			"Medium",
+			"Semi Bold",
+			"Bold",
+			"Extra Bold",
+			"Black"
+		};
+	};
+
+	[12187376545] = {
+		Name = "Tangerine";
+		Styles = { "Regular", "Bold" };
+	};
+
+	[12187376739] = {
+		Name = "Noto Serif SC";
+		Styles = {
+			"Extra Light",
+			"Light",
+			"Regular",
+			"Medium",
+			"Semi Bold",
+			"Bold",
+			"Black"
+		};
+	};
+
+	[11702779517] = {
+		Name = "Montserrat";
+		Styles = {
+			"Thin",
+			"Thin Italic",
+			"Extra Light",
+			"Extra Light Italic",
+			"Light",
+			"Light Italic",
+			"Regular",
+			"Italic",
+			"Medium",
+			"Medium Italic",
+			"Semi Bold",
+			"Semi Bold Italic",
+			"Bold",
+			"Bold Italic",
+			"Extra Bold",
+			"Extra Bold Italic",
+			"Black",
+			"Black Italic"
+		};
+	};
+
+	[12187372629] = {
+		Name = "Mulish";
+		Styles = {
+			"Extra Light",
+			"Extra Light Italic",
+			"Light",
+			"Light Italic",
+			"Regular",
+			"Italic",
+			"Medium",
+			"Medium Italic",
+			"Semi Bold",
+			"Semi Bold Italic",
+			"Bold",
+			"Bold Italic",
+			"Extra Bold",
+			"Extra Bold Italic",
+			"Black",
+			"Black Italic"
+		};
+	};
+
+	[12187607722] = {
+		Name = "Damion";
+		Styles = { "Regular" };
+	};
+
+	[12187377099] = {
+		Name = "Cairo";
+		Styles = {
+			"Extra Light",
+			"Light",
+			"Regular",
+			"Medium",
+			"Semi Bold",
+			"Bold",
+			"Extra Bold",
+			"Black"
+		};
+	};
+
+	[12187365559] = {
+		Name = "Mukta";
+		Styles = {
+			"Extra Light",
+			"Light",
+			"Regular",
+			"Medium",
+			"Semi Bold",
+			"Bold",
+			"Extra Bold"
+		};
+	};
+
+	[12187606783] = {
+		Name = "Monofett";
+		Styles = { "Regular" };
+	};
+
+	[12187371991] = {
+		Name = "Barrio";
+		Styles = { "Regular" };
+	};
+
+	[11598121416] = {
+		Name = "Open Sans";
+		Styles = {
+			"Light",
+			"Light Italic",
+			"Regular",
+			"Italic",
+			"Medium",
+			"Medium Italic",
+			"Semi Bold",
+			"Semi Bold Italic",
+			"Bold",
+			"Bold Italic",
+			"Extra Bold",
+			"Extra Bold Italic"
+		};
+	};
+
+	[12187376357] = {
+		Name = "Sedgwick Ave Display";
+		Styles = { "Regular" };
+	};
+
+	[12187375716] = {
+		Name = "Finger Paint";
+		Styles = { "Regular" };
+	};
+
+	[12187372382] = {
+		Name = "Eater";
+		Styles = { "Regular" };
+	};
+
+	[12187373327] = {
+		Name = "Work Sans";
+		Styles = {
+			"Thin",
+			"Thin Italic",
+			"Extra Light",
+			"Extra Light Italic",
+			"Light",
+			"Light Italic",
+			"Regular",
+			"Italic",
+			"Medium",
+			"Medium Italic",
+			"Semi Bold",
+			"Semi Bold Italic",
+			"Bold",
+			"Bold Italic",
+			"Extra Bold",
+			"Extra Bold Italic",
+			"Black",
+			"Black Italic"
+		};
+	};
+
+	[12187368843] = {
+		Name = "Caesar Dressing";
+		Styles = { "Regular" };
+	};
+
+	[12187373592] = {
+		Name = "Kanit";
+		Styles = {
+			"Thin",
+			"Thin Italic",
+			"Extra Light",
+			"Extra Light Italic",
+			"Light",
+			"Light Italic",
+			"Regular",
+			"Italic",
+			"Medium",
+			"Medium Italic",
+			"Semi Bold",
+			"Semi Bold Italic",
+			"Bold",
+			"Bold Italic",
+			"Extra Bold",
+			"Extra Bold Italic",
+			"Black",
+			"Black Italic"
+		};
+	};
+
+	[16658254058] = {
+		Name = "Arimo";
+		Styles = {
+			"Regular",
+			"Medium",
+			"Semi Bold",
+			"Bold",
+			"Italic",
+			"Medium Italic",
+			"Semi Bold Italic",
+			"Bold Italic"
+		};
+	};
+
+	[12187361378] = {
+		Name = "Hind Siliguri";
+		Styles = {
+			"Light",
+			"Regular",
+			"Medium",
+			"Semi Bold",
+			"Bold"
+		};
+	};
+
+	[12187362120] = {
+		Name = "Rubik Iso";
+		Styles = { "Regular" };
+	};
+
+	[8836875837] = {
+		Name = "Lobster";
+		Styles = { "Regular" };
+	};
+
+	[12187374765] = {
+		Name = "Playfair Display";
+		Styles = {
+			"Regular",
+			"Italic",
+			"Medium",
+			"Medium Italic",
+			"Semi Bold",
+			"Semi Bold Italic",
+			"Bold",
+			"Bold Italic",
+			"Extra Bold",
+			"Extra Bold Italic",
+			"Black",
+			"Black Italic"
+		};
+	};
+
+	[12187374273] = {
+		Name = "Italianno";
+		Styles = { "Regular" };
+	};
+
+	[12187606624] = {
+		Name = "PT Serif";
+		Styles = {
+			"Regular",
+			"Italic",
+			"Bold",
+			"Bold Italic"
+		};
+	};
+
+	[12187371840] = {
+		Name = "Silkscreen";
+		Styles = { "Regular", "Bold" };
+	};
+
+	[12187607493] = {
+		Name = "Shadows Into Light";
+		Styles = { "Regular" };
+	};
+
+	[12187365104] = {
+		Name = "Blaka";
+		Styles = { "Regular" };
+	};
+
+	[12187377325] = {
+		Name = "Nosifer";
+		Styles = { "Regular" };
+	};
+
+	[12187368093] = {
+		Name = "Noto Serif TC";
+		Styles = {
+			"Extra Light",
+			"Light",
+			"Regular",
+			"Medium",
+			"Semi Bold",
+			"Bold",
+			"Black"
+		};
+	};
+
+	[12187373881] = {
+		Name = "Yellowtail";
+		Styles = { "Regular" };
+	};
+
+	[12187367362] = {
+		Name = "Pacifico";
+		Styles = { "Regular" };
+	};
+
+	[12187363887] = {
+		Name = "Codystar";
+		Styles = { "Light", "Regular" };
+	};
+
+	[12187369802] = {
+		Name = "Caveat";
+		Styles = {
+			"Regular",
+			"Medium",
+			"Semi Bold",
+			"Bold"
+		};
+	};
+
+	[12187364648] = {
+		Name = "Marhey";
+		Styles = {
+			"Light",
+			"Regular",
+			"Medium",
+			"Semi Bold",
+			"Bold"
+		};
+	};
+
+	[12187607116] = {
+		Name = "La Belle Aurore";
+		Styles = { "Regular" };
+	};
+
+	[12187362578] = {
+		Name = "Sono Monospace";
+		Styles = {
+			"Extra Light",
+			"Light",
+			"Regular",
+			"Medium",
+			"Semi Bold",
+			"Bold",
+			"Extra Bold"
+		};
+	};
+
+	[16658237174] = {
+		Name = "Builder Extended";
+		Styles = {
+			"Light",
+			"Regular",
+			"Semi Bold",
+			"Bold",
+			"Extra Bold"
+		};
+	};
+
+	[12188570269] = {
+		Name = "M PLUS Rounded 1c";
+		Styles = {
+			"Thin",
+			"Light",
+			"Regular",
+			"Medium",
+			"Bold",
+			"Extra Bold",
+			"Black"
+		};
+	};
+
+	[12187363368] = {
+		Name = "Nunito Sans";
+		Styles = {
+			"Extra Light",
+			"Extra Light Italic",
+			"Light",
+			"Light Italic",
+			"Regular",
+			"Italic",
+			"Semi Bold",
+			"Semi Bold Italic",
+			"Bold",
+			"Bold Italic",
+			"Extra Bold",
+			"Extra Bold Italic",
+			"Black",
+			"Black Italic"
+		};
+	};
+
+	[12187374098] = {
+		Name = "Monoton";
+		Styles = { "Regular" };
+	};
+
+	[11598289817] = {
+		Name = "Lato";
+		Styles = {
+			"Thin",
+			"Thin Italic",
+			"Light",
+			"Light Italic",
+			"Regular",
+			"Italic",
+			"Bold",
+			"Bold Italic",
+			"Black",
+			"Black Italic"
+		};
+	};
+
+	[16658246179] = {
+		Name = "Builder Mono";
+		Styles = { "Light", "Regular", "Bold" };
+	};
+
+	[12187376174] = {
+		Name = "Teko";
+		Styles = {
+			"Light",
+			"Regular",
+			"Medium",
+			"Semi Bold",
+			"Bold"
+		};
+	};
+
+	[8764312106] = {
+		Name = "Dancing Script";
+		Styles = {
+			"Regular",
+			"Medium",
+			"Semi Bold",
+			"Bold"
+		};
+	};
+
+	[12187372175] = {
+		Name = "Rye";
+		Styles = { "Regular" };
+	};
+
+	[12187360881] = {
+		Name = "Audiowide";
+		Styles = { "Regular" };
+	};
+
+	[12187367901] = {
+		Name = "Nothing You Could Do";
+		Styles = { "Regular" };
+	};
+
+	[12187376910] = {
+		Name = "Irish Grover";
+		Styles = { "Regular" };
+	};
+
+	[12187368317] = {
+		Name = "Akronim";
+		Styles = { "Regular" };
+	};
+
+	[12187374954] = {
+		Name = "Fira Sans";
+		Styles = {
+			"Thin",
+			"Thin Italic",
+			"Extra Light",
+			"Extra Light Italic",
+			"Light",
+			"Light Italic",
+			"Regular",
+			"Italic",
+			"Medium",
+			"Medium Italic",
+			"Semi Bold",
+			"Semi Bold Italic",
+			"Bold",
+			"Bold Italic",
+			"Extra Bold",
+			"Extra Bold Italic",
+			"Black",
+			"Black Italic"
+		};
+	};
+
+	[12187370928] = {
+		Name = "Faster One";
+		Styles = { "Regular" };
+	};
+
+	[12187361718] = {
+		Name = "Nanum Gothic";
+		Styles = { "Regular", "Bold", "Extra Bold" };
+	};
+
+	[12187369046] = {
+		Name = "Rubik Wet Paint";
+		Styles = { "Regular" };
+	};
+
+	[11702779409] = {
+		Name = "Poppins";
+		Styles = {
+			"Thin",
+			"Thin Italic",
+			"Extra Light",
+			"Extra Light Italic",
+			"Light",
+			"Light Italic",
+			"Regular",
+			"Italic",
+			"Medium",
+			"Medium Italic",
+			"Semi Bold",
+			"Semi Bold Italic",
+			"Bold",
+			"Bold Italic",
+			"Extra Bold",
+			"Extra Bold Italic",
+			"Black",
+			"Black Italic"
+		};
+	};
+
+	[12187366657] = {
+		Name = "Lora";
+		Styles = {
+			"Regular",
+			"Italic",
+			"Medium",
+			"Medium Italic",
+			"Semi Bold",
+			"Semi Bold Italic",
+			"Bold",
+			"Bold Italic"
+		};
+	};
+
+	[12187365769] = {
+		Name = "Libre Baskerville";
+		Styles = { "Regular", "Italic", "Bold" };
+	};
+
+	[12187606934] = {
+		Name = "PT Sans";
+		Styles = {
+			"Regular",
+			"Italic",
+			"Bold",
+			"Bold Italic"
+		};
+	};
+
+	[16658221428] = {
+		Name = "Builder Sans";
+		Styles = {
+			"Thin",
+			"Light",
+			"Regular",
+			"Medium",
+			"Semi Bold",
+			"Bold",
+			"Extra Bold"
+		};
+	};
+
+	[12187362892] = {
+		Name = "Noto Sans HK";
+		Styles = {
+			"Thin",
+			"Light",
+			"Regular",
+			"Medium",
+			"Bold",
+			"Black"
+		};
+	};
+
+	[12187365364] = {
+		Name = "Inter";
+		Styles = {
+			"Thin",
+			"Extra Light",
+			"Light",
+			"Regular",
+			"Medium",
+			"Semi Bold",
+			"Bold",
+			"Extra Bold",
+			"Black"
+		};
+	};
+
+	[12187371324] = {
+		Name = "Quicksand";
+		Styles = { "Light", "Regular", "Medium", "Semi Bold", "Bold" };
+	};
+
+	[12187375194] = {
+		Name = "Frijole";
+		Styles = { "Regular" };
+	};
+
+	[12187375958] = {
+		Name = "Great Vibes";
+		Styles = { "Regular" };
+	};
+
+	["rbxasset://fonts/families/AccanthisADFStd.json"] = {
+		Name = "Accanthis ADF Std";
+		Styles = { "Regular" };
+	};
+
+	["rbxasset://fonts/families/AmaticSC.json"] = {
+		Name = "Amatic SC";
+		Styles = { "Regular", "Bold" };
+	};
+
+	["rbxasset://fonts/families/Arial.json"] = {
+		Name = "Arial";
+		Styles = { "Regular", "Bold" };
+	};
+
+	["rbxasset://fonts/families/LegacyArial.json"] = {
+		Name = "Arial (Legacy)";
+		Styles = { "Regular", "Bold" };
+	};
+
+	["rbxasset://fonts/families/Balthazar.json"] = {
+		Name = "Balthazar";
+		Styles = { "Regular" };
+	};
+
+	["rbxasset://fonts/families/Bangers.json"] = {
+		Name = "Bangers";
+		Styles = { "Regular" };
+	};
+
+	["rbxasset://fonts/families/ComicNeueAngular.json"] = {
+		Name = "Comic Neue Angular";
+		Styles = { "Bold" };
+	};
+
+	["rbxasset://fonts/families/Creepster.json"] = {
+		Name = "Creepster";
+		Styles = { "Regular" };
+	};
+
+	["rbxasset://fonts/families/DenkOne.json"] = {
+		Name = "Denk One";
+		Styles = { "Regular" };
+	};
+
+	["rbxasset://fonts/families/Fondamento.json"] = {
+		Name = "Fondamento";
+		Styles = { "Regular" };
+	};
+
+	["rbxasset://fonts/families/FredokaOne.json"] = {
+		Name = "Fredoka One";
+		Styles = { "Regular" };
+	};
+
+	["rbxasset://fonts/families/GothamSSm.json"] = {
+		Name = "Gotham SSm";
+		Styles = {
+			"Book",
+			"Medium",
+			"Bold",
+			"Black"
+		};
+	};
+
+	["rbxasset://fonts/families/GrenzeGotisch.json"] = {
+		Name = "Grenze Gotisch";
+		Styles = {
+			"Thin",
+			"Extra Light",
+			"Light",
+			"Regular",
+			"Medium",
+			"Semi Bold",
+			"Bold",
+			"Extra Bold",
+			"Black"
+		};
+	};
+
+	["rbxasset://fonts/families/Guru.json"] = {
+		Name = "Guru";
+		Styles = { "Regular" };
+	};
+
+	["rbxasset://fonts/families/HighwayGothic.json"] = {
+		Name = "Highway Gothic";
+		Styles = { "Regular" };
+	};
+
+	["rbxasset://fonts/families/Inconsolata.json"] = {
+		Name = "Inconsolata";
+		Styles = {
+			"Extra Light",
+			"Light",
+			"Regular",
+			"Medium",
+			"Semi Bold",
+			"Bold",
+			"Extra Bold",
+			"Black"
+		};
+	};
+
+	["rbxasset://fonts/families/IndieFlower.json"] = {
+		Name = "Indie Flower";
+		Styles = { "Regular" };
+	};
+
+	["rbxasset://fonts/families/JosefinSans.json"] = {
+		Name = "Josefin Sans";
+		Styles = {
+			"Thin",
+			"Extra Light",
+			"Light",
+			"Regular",
+			"Medium",
+			"Semi Bold",
+			"Bold"
+		};
+	};
+
+	["rbxasset://fonts/families/Jura.json"] = {
+		Name = "Jura";
+		Styles = {
+			"Light",
+			"Regular",
+			"Medium",
+			"Semi Bold",
+			"Bold"
+		};
+	};
+
+	["rbxasset://fonts/families/Kalam.json"] = {
+		Name = "Kalam";
+		Styles = {
+			"Light",
+			"Regular",
+			"Bold"
+		};
+	};
+
+	["rbxasset://fonts/families/LuckiestGuy.json"] = {
+		Name = "Luckiest Guy";
+		Styles = { "Regular" };
+	};
+
+	["rbxasset://fonts/families/Merriweather.json"] = {
+		Name = "Merriweather";
+		Styles = {
+			"Light",
+			"Regular",
+			"Bold",
+			"Black"
+		};
+	};
+
+	["rbxasset://fonts/families/Michroma.json"] = {
+		Name = "Michroma";
+		Styles = { "Regular" };
+	};
+
+	["rbxasset://fonts/families/Oswald.json"] = {
+		Name = "Oswald";
+		Styles = {
+			"Extra Light",
+			"Light",
+			"Regular",
+			"Medium",
+			"Semi Bold",
+			"Bold"
+		};
+	};
+
+	["rbxasset://fonts/families/PatrickHand.json"] = {
+		Name = "Patrick Hand";
+		Styles = { "Regular" };
+	};
+
+	["rbxasset://fonts/families/PermanentMarker.json"] = {
+		Name = "Permanent Marker";
+		Styles = { "Regular" };
+	};
+
+	["rbxasset://fonts/families/PressStart2P.json"] = {
+		Name = "Press Start 2P";
+		Styles = { "Regular" };
+	};
+
+	["rbxasset://fonts/families/Roboto.json"] = {
+		Name = "Roboto";
+		Styles = {
+			"Thin",
+			"Light",
+			"Regular",
+			"Medium",
+			"Bold",
+			"Black"
+		};
+	};
+
+	["rbxasset://fonts/families/RobotoCondensed.json"] = {
+		Name = "Roboto Condensed";
+		Styles = { "Light", "Regular", "Bold" };
+	};
+
+	["rbxasset://fonts/families/RobotoMono.json"] = {
+		Name = "Roboto Mono";
+		Styles = {
+			"Thin",
+			"Extra Light",
+			"Light",
+			"Regular",
+			"Medium",
+			"Semi Bold",
+			"Bold"
+		};
+	};
+
+	["rbxasset://fonts/families/RomanAntique.json"] = {
+		Name = "Roman Antique";
+		Styles = { "Regular" };
+	};
+
+	["rbxasset://fonts/families/Sarpanch.json"] = {
+		Name = "Sarpanch";
+		Styles = {
+			"Regular",
+			"Medium",
+			"Semi Bold",
+			"Bold",
+			"Extra Bold",
+			"Black"
+		};
+	};
+
+	["rbxasset://fonts/families/SourceSansPro.json"] = {
+		Name = "Source Sans Pro";
+		Styles = {
+			"Extra Light",
+			"Light",
+			"Regular",
+			"Semi Bold",
+			"Bold",
+			"Black"
+		};
+	};
+
+	["rbxasset://fonts/families/SpecialElite.json"] = {
+		Name = "Special Elite";
+		Styles = { "Regular" };
+	};
+
+	["rbxasset://fonts/families/TitilliumWeb.json"] = {
+		Name = "Titillium Web";
+		Styles = {
+			"Extra Light",
+			"Light",
+			"Regular",
+			"Semi Bold",
+			"Bold",
+			"Black"
+		};
+	};
+
+	["rbxasset://fonts/families/Ubuntu.json"] = {
+		Name = "Ubuntu";
+		Styles = {
+			"Light",
+			"Regular",
+			"Medium",
+			"Bold"
+		};
+	};
+
+	["rbxasset://fonts/families/Zekton.json"] = {
+		Name = "Zekton";
+		Styles = { "Regular" };
+	};
+
+	--[[
+	[0] = {
+		Name = "";
+		Styles = {};
+	};
+	--]]
+}

--- a/src/StudioMacros/modules/Shared/Fonts/FontData.luau
+++ b/src/StudioMacros/modules/Shared/Fonts/FontData.luau
@@ -928,7 +928,7 @@ return {
 	["rbxasset://fonts/families/GothamSSm.json"] = {
 		Name = "Gotham SSm";
 		Styles = {
-			"Book",
+			"Regular",
 			"Medium",
 			"Bold",
 			"Black"

--- a/src/StudioMacros/modules/Shared/SearchUtils.luau
+++ b/src/StudioMacros/modules/Shared/SearchUtils.luau
@@ -1,0 +1,87 @@
+local require = require(script.Parent.loader).load(script)
+
+local Fzy = require("Fzy")
+
+local SearchUtils = {}
+
+function SearchUtils.getMatchedString(fzyConfig, targetString, searchQuery)
+	if not fzyConfig or not targetString or not searchQuery then
+		return
+	end
+
+	searchQuery = string.lower(searchQuery)
+
+	local positions = Fzy.positions(fzyConfig, searchQuery, string.lower(targetString))
+	if not positions or #positions == 0 then
+		return targetString
+	end
+
+	local ranges = {}
+	local startPos, endPos = positions[1], positions[1]
+
+	for i = 2, #positions do
+		if positions[i] == endPos + 1 then
+			endPos = positions[i]
+
+			if i == #positions then
+				table.insert(ranges, { startPos, endPos })
+			end
+		else
+			table.insert(ranges, { startPos, endPos })
+			startPos = positions[i]
+			endPos = positions[i]
+		end
+	end
+
+	if #ranges == 0 then
+		return targetString
+	end
+
+	local finalString = ""
+
+	for index, range in ranges do
+		local start = string.sub(targetString, index == 1 and 0 or ranges[index - 1][2] + 1, range[1] - 1)
+		local matched = string.sub(targetString, range[1], range[2])
+
+		finalString ..= `{start}<font color="#d0a4f7">{matched}</font>`
+
+		if index == #ranges then
+			finalString ..= string.sub(targetString, range[2] + 1, string.len(targetString))
+		end
+	end
+
+	return finalString
+end
+
+function SearchUtils.stringIsRGB(str)
+	if not str then
+		return
+	end
+
+	local pattern = "^%s*(%d+)%s*,%s*(%d+)%s*,%s*(%d+)%s*$"
+	local r, g, b = string.match(str, pattern)
+	if r and g and b then
+		r, g, b = tonumber(r), tonumber(g), tonumber(b)
+		local isRGB = r >= 0 and r <= 255 and g >= 0 and g <= 255 and b >= 0 and b <= 255
+		return isRGB, r, g, b
+	end
+	return false
+end
+
+function SearchUtils.stringIsHex(str)
+	if not str then
+		return
+	end
+
+	str = string.lower(str)
+
+	local pattern = "^%s*#?([0-9a-f]+)%s*$"
+	local hex = string.match(str, pattern)
+	if hex then
+		local len = #hex
+		return (len == 6 or len == 3), hex
+	end
+	return false
+end
+
+return SearchUtils


### PR DESCRIPTION
This merges custom search results into the command palette. The code is kinda messy right now so it will need to be refactored in the future, specifically, how we're handling creating the special results directly in the command palette. Ideally each custom results would be broken up into its own object with a generalized API so it's easier for people to add more if they want. I didn't really think about that until I was mostly through hacking these features in... oops.

New:
* Custom results for macros - add `CustomResults` to your macro data to select custom parameters for the macro (see `ChangeBackgroundColor.luau` or `ChangeFontStyle.luau` for examples) - supports `"Color"`, `"Font"`, and `"FontStyle"`
* ChangeBackground/Text/StrokeColor macros
* Change font and font style macros
* `<Shift+Escape>` to release focus from the command palette; note that in order to trigger macros with `<Enter>` you must have the command palette focused. If it's already open, but not focused, you can trigger the studio action to open the command palette again to re-focus it
* Pressing `<Shift+Enter>` on a macro with custom results will send the command palette back to its previous state once you select one of the results with `<Enter>`


https://github.com/user-attachments/assets/b7dfa238-1f0d-48a3-b2c0-ff550789251c