### PR TITLE
feat: Improve color picker inputs and UI selection macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,9 @@ return {
 	-- instance. see: WrapIntoContainer.luau for an example
 	RunOnSelection = true,
 
+	-- when CustomResults is set, the picked values are passed after `plugin`.
+	-- "Color" passes a Color3 and an alpha in 0-1 (1 being opaque), so a color
+	-- macro looks like: function(instance, plugin, color, alpha)
 	Macro = function(instance)
 		instance.Position = Vector3.zero
 		instance.Size = Vector3.one

--- a/src/StudioMacros/macros/Color/ChangeBackgroundColor.luau
+++ b/src/StudioMacros/macros/Color/ChangeBackgroundColor.luau
@@ -8,13 +8,13 @@ return {
 		return gui:IsA("GuiObject")
 	end;
 
-	Macro = function(gui, _, color)
-		if not color then
-			return
-		end
-
+	Macro = function(gui, _, color, alpha)
 		if typeof(color) == "Color3" then
 			gui.BackgroundColor3 = color
+		end
+
+		if type(alpha) == "number" then
+			gui.BackgroundTransparency = 1 - alpha
 		end
 	end;
 }

--- a/src/StudioMacros/macros/Color/ChangeColor.luau
+++ b/src/StudioMacros/macros/Color/ChangeColor.luau
@@ -16,12 +16,14 @@ return function(require)
 			return `Change {ColorPropertyUtils.getLabel(ColorPropertyUtils.getProperty(instance))}`
 		end;
 
-		Macro = function(instance, _, color)
-			if typeof(color) ~= "Color3" then
-				return
+		Macro = function(instance, _, color, alpha)
+			if typeof(color) == "Color3" then
+				ColorPropertyUtils.setColor(instance, color)
 			end
 
-			ColorPropertyUtils.setColor(instance, color)
+			if type(alpha) == "number" then
+				ColorPropertyUtils.setTransparency(instance, 1 - alpha)
+			end
 		end;
 	}
 end

--- a/src/StudioMacros/macros/Color/ChangeStrokeColor.luau
+++ b/src/StudioMacros/macros/Color/ChangeStrokeColor.luau
@@ -8,13 +8,13 @@ return {
 		return gui:IsA("UIStroke")
 	end;
 
-	Macro = function(gui, _, color)
-		if not color then
-			return
-		end
-
+	Macro = function(gui, _, color, alpha)
 		if typeof(color) == "Color3" then
 			gui.Color = color
+		end
+
+		if type(alpha) == "number" then
+			gui.Transparency = 1 - alpha
 		end
 	end;
 }

--- a/src/StudioMacros/macros/Color/ChangeTextColor.luau
+++ b/src/StudioMacros/macros/Color/ChangeTextColor.luau
@@ -10,13 +10,13 @@ return {
 			or gui:IsA("TextBox")
 	end;
 
-	Macro = function(gui, _, color)
-		if not color then
-			return
-		end
-
+	Macro = function(gui, _, color, alpha)
 		if typeof(color) == "Color3" then
 			gui.TextColor3 = color
+		end
+
+		if type(alpha) == "number" then
+			gui.TextTransparency = 1 - alpha
 		end
 	end;
 }

--- a/src/StudioMacros/macros/Instances/WrapIntoContainer.luau
+++ b/src/StudioMacros/macros/Instances/WrapIntoContainer.luau
@@ -1,14 +1,24 @@
+local function isDescendantOfAny(instance, others)
+	for _, other in others do
+		if other ~= instance and instance:IsDescendantOf(other) then
+			return true
+		end
+	end
+
+	return false
+end
+
 return {
 	Name = "Wrap into Container";
 	Description = "Wrap the selected GuiObjects in a transparent container frame.";
 	RunOnSelection = true;
 
-	Predicate = function(gui)
-		return gui:IsA("GuiObject") and gui.Parent ~= nil
+	Predicate = function(instance)
+		return (instance:IsA("GuiObject") or instance:IsA("UIComponent")) and instance.Parent ~= nil
 	end;
 
-	Macro = function(guis)
-		local first = guis[1]
+	Macro = function(instances)
+		local first = instances[1]
 
 		local container = Instance.new("Frame")
 		container.Name = "container"
@@ -16,7 +26,7 @@ return {
 		container.BackgroundTransparency = 1
 		container.BorderSizePixel = 0
 
-		if #guis == 1 then
+		if #instances == 1 and first:IsA("GuiObject") then
 			container.AnchorPoint = first.AnchorPoint
 			container.Position = first.Position
 			container.Size = first.Size
@@ -31,12 +41,12 @@ return {
 			container.Size = UDim2.fromScale(1, 1)
 			container.Parent = first.Parent
 
-			for _, gui in guis do
-				if container:IsDescendantOf(gui) then
+			for _, instance in instances do
+				if container:IsDescendantOf(instance) or isDescendantOfAny(instance, instances) then
 					continue
 				end
 
-				gui.Parent = container
+				instance.Parent = container
 			end
 		end
 

--- a/src/StudioMacros/macros/Properties/ToggleVisibility.luau
+++ b/src/StudioMacros/macros/Properties/ToggleVisibility.luau
@@ -1,9 +1,13 @@
+local function usesEnabled(gui)
+	return gui:IsA("LayerCollector") or gui:IsA("UIStroke") or gui:IsA("UIGradient")
+end
+
 return {
 	Name = "Toggle Visibility";
 	Description = "Toggle the object's visibility.";
 
 	Predicate = function(gui)
-		return gui ~= nil and (gui:IsA("GuiObject") or gui:IsA("ScreenGui") or gui:IsA("UIStroke") or gui:IsA("UIGradient"))
+		return gui ~= nil and (gui:IsA("GuiObject") or usesEnabled(gui))
 	end;
 
 	ToggleValue = function(gui)
@@ -11,7 +15,7 @@ return {
 			return nil
 		end
 
-		if gui:IsA("ScreenGui") or gui:IsA("UIStroke") or gui:IsA("UIGradient") then
+		if usesEnabled(gui) then
 			return gui.Enabled
 		else
 			return gui.Visible
@@ -19,7 +23,7 @@ return {
 	end;
 
 	Macro = function(gui)
-		if gui:IsA("ScreenGui") or gui:IsA("UIStroke") or gui:IsA("UIGradient") then
+		if usesEnabled(gui) then
 			gui.Enabled = not gui.Enabled
 		else
 			gui.Visible = not gui.Visible

--- a/src/StudioMacros/modules/Shared/ColorPropertyUtils.luau
+++ b/src/StudioMacros/modules/Shared/ColorPropertyUtils.luau
@@ -2,6 +2,7 @@ local ColorPropertyUtils = {}
 
 local RULES = {
 	{ ClassName = "UIStroke"; Property = "Color" };
+	{ ClassName = "UIShadow"; Property = "Color" };
 	{ ClassName = "TextLabel"; Property = "TextColor3" };
 	{ ClassName = "TextButton"; Property = "TextColor3" };
 	{ ClassName = "TextBox"; Property = "TextColor3" };

--- a/src/StudioMacros/modules/Shared/ColorPropertyUtils.luau
+++ b/src/StudioMacros/modules/Shared/ColorPropertyUtils.luau
@@ -48,6 +48,61 @@ function ColorPropertyUtils.getColor(instance: Instance?): Color3?
 	return value
 end
 
+local TRANSPARENCY_PROPERTIES = {
+	BackgroundColor3 = "BackgroundTransparency";
+	Color = "Transparency";
+	Color3 = "Transparency";
+	FillColor = "FillTransparency";
+	ImageColor3 = "ImageTransparency";
+	TextColor3 = "TextTransparency";
+}
+
+--[[
+	Maps a color property to the transparency property that pairs with it. The
+	classes without one (Light, Atmosphere) still map, so callers have to read
+	the property back to know whether it actually exists.
+]]
+function ColorPropertyUtils.getTransparencyPropertyFor(colorProperty: string?): string?
+	if not colorProperty then
+		return nil
+	end
+
+	return TRANSPARENCY_PROPERTIES[colorProperty]
+end
+
+function ColorPropertyUtils.getTransparencyProperty(instance: Instance?): string?
+	return ColorPropertyUtils.getTransparencyPropertyFor(ColorPropertyUtils.getProperty(instance))
+end
+
+function ColorPropertyUtils.getTransparency(instance: Instance?): number?
+	local property = ColorPropertyUtils.getTransparencyProperty(instance)
+	if not property then
+		return nil
+	end
+
+	local success, value = pcall(function()
+		return (instance :: any)[property]
+	end)
+
+	if not success or typeof(value) ~= "number" then
+		return nil
+	end
+
+	return value
+end
+
+function ColorPropertyUtils.setTransparency(instance: Instance?, transparency: number): string?
+	local property = ColorPropertyUtils.getTransparencyProperty(instance)
+	if not property or ColorPropertyUtils.getTransparency(instance) == nil then
+		return nil
+	end
+
+	local target = instance :: any
+	target[property] = transparency
+
+	return property
+end
+
 function ColorPropertyUtils.setColor(instance: Instance?, color: Color3): string?
 	local property = ColorPropertyUtils.getProperty(instance)
 	if not property or ColorPropertyUtils.getColor(instance) == nil then

--- a/src/StudioMacros/modules/Shared/CommandPalette/CommandPalette.luau
+++ b/src/StudioMacros/modules/Shared/CommandPalette/CommandPalette.luau
@@ -12,6 +12,7 @@ local Blend = require("Blend")
 local ButtonHighlightModel = require("ButtonHighlightModel")
 local ColorEntry = require("ColorEntry")
 local ColorPickerPane = require("ColorPickerPane")
+local ColorPropertyUtils = require("ColorPropertyUtils")
 local CommandGroup = require("CommandGroup")
 local FontData = require("FontData")
 local FontEntry = require("FontEntry")
@@ -883,6 +884,27 @@ function CommandPalette:_setupColorResults()
 			return value
 		end
 
+		local function resolveTransparencyProperty(instance)
+			return ColorPropertyUtils.getTransparencyPropertyFor(resolveProperty(instance))
+		end
+
+		local function readTransparency(instance)
+			local property = resolveTransparencyProperty(instance)
+			if not property then
+				return nil
+			end
+
+			local success, value = pcall(function()
+				return instance[property]
+			end)
+
+			if not success or typeof(value) ~= "number" then
+				return nil
+			end
+
+			return value
+		end
+
 		local seedInstance
 		for _, instance in initialSelection do
 			if readColor(instance) then
@@ -895,15 +917,22 @@ function CommandPalette:_setupColorResults()
 			return
 		end
 
-		colorPickerPane:SetColor(readColor(seedInstance))
+		local function seedFrom(instance)
+			colorPickerPane:SetColor(readColor(instance))
+
+			local transparency = readTransparency(instance)
+			colorPickerPane:SetAlpha(transparency and 1 - transparency or 1)
+		end
+
+		seedFrom(seedInstance)
 
 		-- Undo/redo support
 		maid:GiveTask(ChangeHistoryService.OnUndo:Connect(function()
-			colorPickerPane:SetColor(readColor(seedInstance))
+			seedFrom(seedInstance)
 		end))
 
 		maid:GiveTask(ChangeHistoryService.OnRedo:Connect(function()
-			colorPickerPane:SetColor(readColor(seedInstance))
+			seedFrom(seedInstance)
 		end))
 
 		maid:GiveTask(colorPickerPane:ObserveColor():Subscribe(function(newColor)
@@ -919,10 +948,25 @@ function CommandPalette:_setupColorResults()
 			end
 		end))
 
+		maid:GiveTask(colorPickerPane:ObserveAlpha():Subscribe(function(alpha)
+			if not alpha then
+				return
+			end
+
+			local newTransparency = 1 - alpha
+
+			for _, instance in initialSelection do
+				local current = readTransparency(instance)
+				if current and current ~= newTransparency then
+					instance[resolveTransparencyProperty(instance)] = newTransparency
+				end
+			end
+		end))
+
 		-- Since we don't want to spam the undo stack as they're picking a
 		-- color, we only want to fire the macro when the user stops dragging
-		maid:GiveTask(colorPickerPane.ColorUpdated:Connect(function(newColor)
-			self.CustomResultActivated:Fire("Color", true, newColor)
+		maid:GiveTask(colorPickerPane.ColorUpdated:Connect(function(newColor, alpha)
+			self.CustomResultActivated:Fire("Color", true, newColor, alpha)
 		end))
 	end))
 
@@ -940,7 +984,7 @@ function CommandPalette:_setupColorResults()
 
 		self._maid:GiveTask(entry.Activated:Connect(function(shiftPressed)
 			colorPickerPane:SetColor(brickColor.Color)
-			self.CustomResultActivated:Fire("Color", shiftPressed, brickColor.Color)
+			self.CustomResultActivated:Fire("Color", shiftPressed, brickColor.Color, colorPickerPane.CurrentAlpha.Value)
 		end))
 	end
 
@@ -1681,14 +1725,16 @@ function CommandPalette:Render(props)
 												if self._colorPicker then
 													self._colorPicker:SetColor(newColor)
 												end
-												self.CustomResultActivated:Fire("Color", shiftPressed, newColor)
+												self.CustomResultActivated:Fire("Color", shiftPressed, newColor,
+													self._colorPicker and self._colorPicker.CurrentAlpha.Value)
 											elseif SearchUtils.stringIsHex(currentText) then
 												local _, hex = SearchUtils.stringIsHex(currentText)
 												local newColor = Color3.fromHex(hex)
 												if self._colorPicker then
 													self._colorPicker:SetColor(newColor)
 												end
-												self.CustomResultActivated:Fire("Color", shiftPressed, newColor)
+												self.CustomResultActivated:Fire("Color", shiftPressed, newColor,
+													self._colorPicker and self._colorPicker.CurrentAlpha.Value)
 											end
 										elseif customResultsType == "Number" then
 											local value = self:EvaluateNumberInput(self._input.Text)

--- a/src/StudioMacros/modules/Shared/CommandPalette/Input/Color/ColorPickerPane.luau
+++ b/src/StudioMacros/modules/Shared/CommandPalette/Input/Color/ColorPickerPane.luau
@@ -39,15 +39,16 @@ local INPUT_ICON_SIZE = INPUT_ROW_HEIGHT - INPUT_PADDING * 2
 local INPUT_CHARACTER_WIDTH = math.ceil(INPUT_TEXT_SIZE * 0.6)
 local INPUTS_WIDTH = math.ceil(INPUT_PADDING * 2 + INPUT_ICON_SIZE + INPUT_ROW_PADDING + #"255, 255, 255" * INPUT_CHARACTER_WIDTH)
 
-local OPACITY_WIDTH = math.ceil(INPUT_PADDING * 2 + #"100%" * INPUT_CHARACTER_WIDTH)
+local TRANSPARENCY_WIDTH = math.ceil(INPUT_PADDING * 2 + #"0.00" * INPUT_CHARACTER_WIDTH)
 
-local function parseOpacity(text: string): number?
-	local percent = tonumber((string.gsub(text, "%%", "")))
-	if not percent then
+--- Reads a Transparency-style 0-1 value and returns it as alpha.
+local function parseTransparency(text: string): number?
+	local value = tonumber(text)
+	if not value then
 		return nil
 	end
 
-	return math.clamp(percent, 0, 100) / 100
+	return 1 - math.clamp(value, 0, 1)
 end
 
 local ColorPickerPane = setmetatable({}, BasicPane)
@@ -1026,7 +1027,7 @@ function ColorPickerPane:Render(props)
 
 						[Blend.Instance] = function(textBox)
 							self._rgbInput = textBox
-							table.insert(self._tabInputMap, 1, textBox)
+							self._tabInputMap[1] = textBox
 						end;
 
 						[Blend.OnChange "Text"] = function(newText)
@@ -1076,7 +1077,7 @@ function ColorPickerPane:Render(props)
 				Blend.New "Frame" {
 					Name = "hexValues";
 					BackgroundTransparency = 1;
-					LayoutOrder = 2;
+					LayoutOrder = 3;
 					Size = UDim2.fromScale(1, 1);
 
 					Blend.New "UIListLayout" {
@@ -1152,7 +1153,7 @@ function ColorPickerPane:Render(props)
 
 							[Blend.Instance] = function(textBox)
 								self._hexInput = textBox
-								table.insert(self._tabInputMap, 2, textBox)
+								self._tabInputMap[5] = textBox
 							end;
 
 							[Blend.OnChange "Text"] = function(newText)
@@ -1200,11 +1201,11 @@ function ColorPickerPane:Render(props)
 					};
 
 					Blend.New "Frame" {
-						Name = "opacity";
+						Name = "transparency";
 						BackgroundColor3 = Color3.fromRGB(15, 15, 15);
 						BackgroundTransparency = transparency;
 						LayoutOrder = 2;
-						Size = UDim2.new(0, OPACITY_WIDTH, 1, 0);
+						Size = UDim2.new(0, TRANSPARENCY_WIDTH, 1, 0);
 
 						Blend.New "UIFlexItem" {
 							FlexMode = Enum.UIFlexMode.None;
@@ -1239,47 +1240,47 @@ function ColorPickerPane:Render(props)
 							ZIndex = 5;
 
 							PlaceholderText = Blend.Computed(self.CurrentAlpha, function(alpha)
-								return `{math.round(alpha * 100)}%`
+								return string.format("%.2f", 1 - alpha)
 							end);
 
 							[Blend.Instance] = function(textBox)
-								self._opacityInput = textBox
-								table.insert(self._tabInputMap, 3, textBox)
+								self._transparencyInput = textBox
+								self._tabInputMap[6] = textBox
 							end;
 
 							[Blend.OnChange "Text"] = function(newText)
-								if not self._opacityInput or not self._opacityInput:IsFocused() then
+								if not self._transparencyInput or not self._transparencyInput:IsFocused() then
 									return
 								end
 
-								if newText == self._opacityInput.PlaceholderText then
+								if newText == self._transparencyInput.PlaceholderText then
 									return
 								end
 
-								local alpha = parseOpacity(newText)
+								local alpha = parseTransparency(newText)
 								if alpha then
 									self:SetAlpha(alpha)
 								end
 							end;
 
 							[Blend.OnEvent "Focused"] = function()
-								self:_handleFocused(self._opacityInput)
+								self:_handleFocused(self._transparencyInput)
 							end;
 
 							[Blend.OnEvent "FocusLost"] = function(enterPressed)
-								if not self._opacityInput then
+								if not self._transparencyInput then
 									return
 								end
 
-								local text = self._opacityInput.Text
-								if enterPressed and text ~= self._opacityInput.PlaceholderText then
-									local alpha = parseOpacity(text)
+								local text = self._transparencyInput.Text
+								if enterPressed and text ~= self._transparencyInput.PlaceholderText then
+									local alpha = parseTransparency(text)
 									if alpha then
 										self:SetAlpha(alpha)
 									end
 								end
 
-								self._opacityInput.Text = ""
+								self._transparencyInput.Text = ""
 								self:_handleFocusLost()
 							end;
 						};
@@ -1288,7 +1289,7 @@ function ColorPickerPane:Render(props)
 
 				Blend.New "Frame" {
 					Name = "rgbValues";
-					LayoutOrder = 3;
+					LayoutOrder = 2;
 					Size = UDim2.fromScale(1, 1);
 					BackgroundTransparency = 1;
 
@@ -1342,7 +1343,7 @@ function ColorPickerPane:Render(props)
 
 							[Blend.Instance] = function(textBox)
 								self._rInput = textBox
-								table.insert(self._tabInputMap, 4, textBox)
+								self._tabInputMap[2] = textBox
 							end;
 
 							[Blend.OnChange "Text"] = function(newText)
@@ -1440,7 +1441,7 @@ function ColorPickerPane:Render(props)
 
 							[Blend.Instance] = function(textBox)
 								self._gInput = textBox
-								table.insert(self._tabInputMap, 5, textBox)
+								self._tabInputMap[3] = textBox
 							end;
 
 							[Blend.OnChange "Text"] = function(newText)
@@ -1538,7 +1539,7 @@ function ColorPickerPane:Render(props)
 
 							[Blend.Instance] = function(textBox)
 								self._bInput = textBox
-								table.insert(self._tabInputMap, 6, textBox)
+								self._tabInputMap[4] = textBox
 							end;
 
 							[Blend.OnChange "Text"] = function(newText)

--- a/src/StudioMacros/modules/Shared/CommandPalette/Input/Color/ColorPickerPane.luau
+++ b/src/StudioMacros/modules/Shared/CommandPalette/Input/Color/ColorPickerPane.luau
@@ -15,14 +15,45 @@ local ValueObject = require("ValueObject")
 
 local TWEEN_INFO = TweenInfo.new(0.2, Enum.EasingStyle.Quart, Enum.EasingDirection.Out)
 
-local SLIDER_COUNT = 3
+local SLIDER_COUNT = 4
 local SLIDER_PADDING = 10
 local SLIDER_WIDTH = 16
+
+local PANE_HEIGHT = 160
+local WRAPPER_INSET = 10
+
+local INPUT_PADDING = 10
+local INPUT_ROW_COUNT = 3
+local INPUT_ROW_PADDING = 5
+local INPUT_TEXT_SIZE = 18
+
+local INPUT_ROW_HEIGHT = (PANE_HEIGHT - WRAPPER_INSET - (INPUT_ROW_COUNT - 1) * INPUT_ROW_PADDING) / INPUT_ROW_COUNT
+local INPUT_ICON_SIZE = INPUT_ROW_HEIGHT - INPUT_PADDING * 2
+
+--[[
+	The inputs are only useful when their placeholder is fully readable, so the
+	column can't flex with the window. RobotoMono advances every glyph by 0.6em,
+	which makes the widest row exactly its longest placeholder ("255, 255, 255")
+	sitting next to the icon. The color square absorbs resizing instead.
+]]
+local INPUT_CHARACTER_WIDTH = math.ceil(INPUT_TEXT_SIZE * 0.6)
+local INPUTS_WIDTH = math.ceil(INPUT_PADDING * 2 + INPUT_ICON_SIZE + INPUT_ROW_PADDING + #"255, 255, 255" * INPUT_CHARACTER_WIDTH)
+
+local OPACITY_WIDTH = math.ceil(INPUT_PADDING * 2 + #"100%" * INPUT_CHARACTER_WIDTH)
+
+local function parseOpacity(text: string): number?
+	local percent = tonumber((string.gsub(text, "%%", "")))
+	if not percent then
+		return nil
+	end
+
+	return math.clamp(percent, 0, 100) / 100
+end
 
 local ColorPickerPane = setmetatable({}, BasicPane)
 ColorPickerPane.ClassName = "ColorPickerPane"
 ColorPickerPane.CustomResultType = "Color"
-ColorPickerPane.Height = 160
+ColorPickerPane.Height = PANE_HEIGHT
 ColorPickerPane.Pinned = true
 ColorPickerPane.__index = ColorPickerPane
 
@@ -31,14 +62,15 @@ function ColorPickerPane.new()
 
 	self._tabInputMap = {}
 
-	self._currentBrightness = self._maid:Add(ValueObject.new(nil))
-	self._currentHue = self._maid:Add(ValueObject.new(nil))
-	self._currentSaturation = self._maid:Add(ValueObject.new(nil))
+	self._currentBrightness = self._maid:Add(ValueObject.new(1))
+	self._currentHue = self._maid:Add(ValueObject.new(0))
+	self._currentSaturation = self._maid:Add(ValueObject.new(0))
 	self._percentVisibleTarget = self._maid:Add(ValueObject.new(0))
 	self._tabInputIndex = self._maid:Add(ValueObject.new(nil))
 	self._targetParent = self._maid:Add(ValueObject.new(nil))
 
 	self.ColorUpdated = self._maid:Add(Signal.new())
+	self.CurrentAlpha = self._maid:Add(ValueObject.new(1))
 	self.CurrentColor = self._maid:Add(ValueObject.new(Color3.new(1, 1, 1)))
 	self.TabReturned = self._maid:Add(Signal.new())
 
@@ -102,7 +134,37 @@ function ColorPickerPane:ObserveColor()
 	return self.CurrentColor:Observe()
 end
 
-function ColorPickerPane:SetColor(color)
+function ColorPickerPane:ObserveAlpha()
+	return self.CurrentAlpha:Observe()
+end
+
+function ColorPickerPane:SetAlpha(alpha: number)
+	self.CurrentAlpha.Value = math.clamp(alpha, 0, 1)
+end
+
+--[[
+	Sets the color and realigns the sliders to match it. Hue is left where the
+	user put it when the incoming color is grayscale, and saturation when it's
+	black, because ToHSV can't recover either from those and would otherwise
+	snap both sliders back to red.
+]]
+function ColorPickerPane:SetColor(color: Color3)
+	local hue, saturation, brightness = color:ToHSV()
+
+	self._settingColor = true
+
+	if saturation > 0 then
+		self._currentHue.Value = hue
+	end
+
+	if brightness > 0 then
+		self._currentSaturation.Value = saturation
+	end
+
+	self._currentBrightness.Value = brightness
+
+	self._settingColor = false
+
 	self.CurrentColor.Value = color
 end
 
@@ -159,7 +221,7 @@ function ColorPickerPane:_endDrag()
 	end
 
 	self._dragging = nil
-	self.ColorUpdated:Fire(self.CurrentColor.Value)
+	self.ColorUpdated:Fire(self.CurrentColor.Value, self.CurrentAlpha.Value)
 end
 
 function ColorPickerPane:_updateDragPosition(position: Vector2)
@@ -169,6 +231,8 @@ function ColorPickerPane:_updateDragPosition(position: Vector2)
 		self:_updateSaturationPosition(position)
 	elseif self._dragging == "Brightness" then
 		self:_updateBrightnessPosition(position)
+	elseif self._dragging == "Alpha" then
+		self:_updateAlphaPosition(position)
 	elseif self._dragging == "Cursor" then
 		self:_updateCursorPosition(position)
 	end
@@ -222,6 +286,17 @@ function ColorPickerPane:_updateBrightnessPosition(position: Vector2)
 	self._currentBrightness.Value = math.abs(1 - value)
 end
 
+function ColorPickerPane:_updateAlphaPosition(position: Vector2)
+	if not self._alpha then
+		return
+	end
+
+	local relativeY = position.Y - self._alpha.AbsolutePosition.Y
+	local alpha = math.clamp(relativeY / self._alpha.AbsoluteSize.Y, 0, 1)
+
+	self.CurrentAlpha.Value = math.abs(1 - alpha)
+end
+
 function ColorPickerPane:SetTargetParent(targetParent)
 	self._targetParent.Value = targetParent
 end
@@ -238,13 +313,8 @@ function ColorPickerPane:Render(props)
 	local targetColor = self._maid:Add(Instance.new("Color3Value"))
 
 	self._maid:GiveTask(Blend.Computed(self._currentHue, self._currentSaturation, self._currentBrightness, function(hue, saturation, brightness)
-		if not hue or not saturation or not brightness then
-			local currentColor = self.CurrentColor.Value
-			if not currentColor then
-				return
-			end
-
-			hue, saturation, brightness = currentColor:ToHSV()
+		if self._settingColor then
+			return
 		end
 
 		self.CurrentColor.Value = Color3.fromHSV(hue, saturation, brightness)
@@ -253,21 +323,6 @@ function ColorPickerPane:Render(props)
 	self._maid:GiveTask(self.CurrentColor:Observe():Subscribe(function(newColor)
 		if not newColor then
 			return
-		end
-
-		local h, s, v = newColor:ToHSV()
-		-- Fill default hsv values
-		local currentHue = self._currentHue.Value
-		if not currentHue or h ~= self._currentHue.Value then
-			self._currentHue.Value = h
-		end
-		local currentSaturation = self._currentSaturation.Value
-		if not currentSaturation or s ~= self._currentSaturation.Value then
-			self._currentSaturation.Value = s
-		end
-		local currentBrightness = self._currentBrightness.Value
-		if not currentBrightness or v ~= self._currentBrightness.Value then
-			self._currentBrightness.Value = v
 		end
 
 		TweenService:Create(targetColor, TWEEN_INFO, {
@@ -280,6 +335,7 @@ function ColorPickerPane:Render(props)
 	local percentHue = Blend.Spring(self._currentHue, 35, 0.9)
 	local percentSaturation = Blend.Spring(self._currentSaturation, 35, 0.9)
 	local percentBrightness = Blend.Spring(self._currentBrightness, 35, 0.9)
+	local percentAlpha = Blend.Spring(self.CurrentAlpha, 35, 0.9)
 
 	local pickerCursorX = Blend.Spring(percentSaturation:Pipe({
 		Rx.map(function(percent)
@@ -328,7 +384,7 @@ function ColorPickerPane:Render(props)
 		Blend.New "Frame" {
 			Name = "wrapper";
 			BackgroundTransparency = 1;
-			Size = UDim2.new(1, 0, 1, -10);
+			Size = UDim2.new(1, 0, 1, -WRAPPER_INSET);
 
 			Blend.New "UIListLayout" {
 				FillDirection = Enum.FillDirection.Horizontal;
@@ -361,8 +417,11 @@ function ColorPickerPane:Render(props)
 				Name = "selection";
 				BackgroundTransparency = 1;
 				LayoutOrder = 2;
-				Size = UDim2.fromScale(0.5, 1);
 				ZIndex = 3;
+
+				-- Kept small so it's always the piece that grows into the space
+				-- the fixed columns leave over, however narrow the window gets.
+				Size = UDim2.fromScale(0.3, 1);
 
 				Blend.New "Frame" {
 					Name = "background";
@@ -371,6 +430,7 @@ function ColorPickerPane:Render(props)
 
 					Blend.New "Frame" {
 						Name = "white";
+						BackgroundColor3 = Color3.fromRGB(255, 255, 255);
 						BackgroundTransparency = transparency;
 						Size = UDim2.fromScale(1, 1);
 						ZIndex = 2;
@@ -408,9 +468,12 @@ function ColorPickerPane:Render(props)
 
 					Blend.New "Frame" {
 						Name = "color";
-						BackgroundColor3 = targetColor;
 						BackgroundTransparency = props.Transparency;
 						Size = UDim2.fromScale(1, 1);
+
+						BackgroundColor3 = Blend.Computed(percentHue, function(hue)
+							return Color3.fromHSV(math.clamp(hue, 0, 1), 1, 1)
+						end);
 
 						Blend.New "UICorner" {
 							CornerRadius = UDim.new(0, 5);
@@ -801,19 +864,101 @@ function ColorPickerPane:Render(props)
 						end;
 					};
 				};
+
+				Blend.New "Frame" {
+					Name = "alpha";
+					BackgroundTransparency = 1;
+					LayoutOrder = 4;
+					Size = UDim2.new(0, SLIDER_WIDTH, 1, 0);
+
+					Blend.New "Frame" {
+						Name = "container";
+						BackgroundColor3 = targetColor;
+						BackgroundTransparency = transparency;
+						Size = UDim2.fromScale(1, 1);
+						ZIndex = 2;
+
+						Blend.New "UIStroke" {
+							Color = Color3.fromRGB(40, 40, 40);
+							Transparency = transparency;
+						};
+
+						Blend.New "UICorner" {
+							CornerRadius = UDim.new(0, 3);
+						};
+
+						Blend.New "UIGradient" {
+							Rotation = 90;
+							Transparency = NumberSequence.new(0, 1);
+						};
+
+						Blend.New "Frame" {
+							Name = "cursor";
+							AnchorPoint = Vector2.new(0.5, 0.5);
+							BackgroundTransparency = transparency;
+							Size = UDim2.fromScale(1.2, 1);
+
+							Position = Blend.Computed(percentAlpha, function(percent)
+								return UDim2.fromScale(0.5, 1 - percent)
+							end);
+
+							Blend.New "UIAspectRatioConstraint" {
+								AspectRatio = 2.5;
+							};
+
+							Blend.New "UICorner" {
+								CornerRadius = UDim.new(0, 2);
+							};
+
+							Blend.New "UIStroke" {
+								Color = Color3.fromRGB(230, 230, 230);
+								Transparency = transparency;
+							};
+						};
+					};
+
+					Blend.New "TextButton" {
+						Name = "button";
+						Size = UDim2.fromScale(1, 1);
+						BackgroundColor3 = Color3.fromRGB(163, 162, 165);
+						BackgroundTransparency = 1;
+						TextColor3 = Color3.fromRGB(27, 42, 53);
+						TextSize = 8;
+						ZIndex = 5;
+
+						[Blend.Instance] = function(instance)
+							self._alpha = instance
+						end;
+
+						[Blend.OnEvent "InputBegan"] = function(input)
+							if self:_isValidInput(input) then
+								self:_beginDrag("Alpha", input)
+							end
+						end;
+
+						[Blend.OnEvent "InputEnded"] = function(input)
+							if self:_isValidInput(input) then
+								self:_endDrag()
+							end
+						end;
+					};
+				};
 			};
 
 			Blend.New "Frame" {
 				Name = "inputs";
 				BackgroundTransparency = 1;
 				LayoutOrder = 4;
-				Position = UDim2.fromScale(0.780371, 0);
-				Size = UDim2.fromScale(0.2, 1);
+				Size = UDim2.new(0, INPUTS_WIDTH, 1, 0);
 				ZIndex = 2;
+
+				Blend.New "UIFlexItem" {
+					FlexMode = Enum.UIFlexMode.None;
+				};
 
 				Blend.New "UIListLayout" {
 					HorizontalAlignment = Enum.HorizontalAlignment.Center;
-					Padding = UDim.new(0, 5);
+					Padding = UDim.new(0, INPUT_ROW_PADDING);
 					VerticalAlignment = Enum.VerticalAlignment.Center;
 					VerticalFlex = Enum.UIFlexAlignment.Fill;
 				};
@@ -838,15 +983,15 @@ function ColorPickerPane:Render(props)
 						FillDirection = Enum.FillDirection.Horizontal;
 						HorizontalAlignment = Enum.HorizontalAlignment.Center;
 						HorizontalFlex = Enum.UIFlexAlignment.Fill;
-						Padding = UDim.new(0, 5);
+						Padding = UDim.new(0, INPUT_ROW_PADDING);
 						VerticalAlignment = Enum.VerticalAlignment.Center;
 					};
 
 					Blend.New "UIPadding" {
-						PaddingBottom = UDim.new(0, 10);
-						PaddingLeft = UDim.new(0, 10);
-						PaddingRight = UDim.new(0, 10);
-						PaddingTop = UDim.new(0, 10);
+						PaddingBottom = UDim.new(0, INPUT_PADDING);
+						PaddingLeft = UDim.new(0, INPUT_PADDING);
+						PaddingRight = UDim.new(0, INPUT_PADDING);
+						PaddingTop = UDim.new(0, INPUT_PADDING);
 					};
 
 					Blend.New "ImageLabel" {
@@ -871,7 +1016,7 @@ function ColorPickerPane:Render(props)
 						FontFace = Font.new("rbxasset://fonts/families/RobotoMono.json", Enum.FontWeight.SemiBold, Enum.FontStyle.Normal);
 						PlaceholderColor3 = Color3.fromRGB(80, 80, 80);
 						TextColor3 = Color3.fromRGB(255, 255, 255);
-						TextSize = 18;
+						TextSize = INPUT_TEXT_SIZE;
 						TextXAlignment = Enum.TextXAlignment.Left;
 						ZIndex = 5;
 
@@ -929,114 +1074,215 @@ function ColorPickerPane:Render(props)
 				};
 
 				Blend.New "Frame" {
-					Name = "hex";
-					BackgroundColor3 = Color3.fromRGB(15, 15, 15);
-					BackgroundTransparency = transparency;
+					Name = "hexValues";
+					BackgroundTransparency = 1;
 					LayoutOrder = 2;
 					Size = UDim2.fromScale(1, 1);
-
-					Blend.New "UICorner" {
-						CornerRadius = UDim.new(0, 5);
-					};
-
-					Blend.New "UIStroke" {
-						Color = Color3.fromRGB(40, 40, 40);
-						Transparency = transparency;
-					};
 
 					Blend.New "UIListLayout" {
 						FillDirection = Enum.FillDirection.Horizontal;
 						HorizontalAlignment = Enum.HorizontalAlignment.Center;
 						HorizontalFlex = Enum.UIFlexAlignment.Fill;
-						Padding = UDim.new(0, 5);
+						Padding = UDim.new(0, INPUT_ROW_PADDING);
 						VerticalAlignment = Enum.VerticalAlignment.Center;
 					};
 
-					Blend.New "UIPadding" {
-						PaddingBottom = UDim.new(0, 10);
-						PaddingLeft = UDim.new(0, 10);
-						PaddingRight = UDim.new(0, 10);
-						PaddingTop = UDim.new(0, 10);
-					};
-
-					Blend.New "ImageLabel" {
-						Name = "icon";
-						BackgroundTransparency = 1;
-						Image = "rbxassetid://6035078895";
-						ImageColor3 = Color3.fromRGB(75, 75, 75);
-						ImageTransparency = transparency;
+					Blend.New "Frame" {
+						Name = "hex";
+						BackgroundColor3 = Color3.fromRGB(15, 15, 15);
+						BackgroundTransparency = transparency;
 						LayoutOrder = 1;
 						Size = UDim2.fromScale(1, 1);
 
-						Blend.New "UIAspectRatioConstraint" {
-							AspectRatio = 1;
+						Blend.New "UICorner" {
+							CornerRadius = UDim.new(0, 5);
 						};
-					};
 
-					Blend.New "TextBox" {
-						Name = "input";
-						BackgroundColor3 = Color3.fromRGB(163, 162, 165);
-						BackgroundTransparency = 1;
-						FontFace = Font.new("rbxasset://fonts/families/RobotoMono.json", Enum.FontWeight.SemiBold, Enum.FontStyle.Normal);
-						LayoutOrder = 2;
-						PlaceholderColor3 = Color3.fromRGB(80, 80, 80);
-						Size = UDim2.fromScale(1, 1);
-						TextColor3 = Color3.fromRGB(255, 255, 255);
-						TextSize = 18;
-						TextTransparency = transparency;
-						TextXAlignment = Enum.TextXAlignment.Left;
-						ZIndex = 5;
+						Blend.New "UIStroke" {
+							Color = Color3.fromRGB(40, 40, 40);
+							Transparency = transparency;
+						};
 
-						PlaceholderText = Blend.Computed(targetColor, function(color)
-							return color:ToHex()
-						end);
+						Blend.New "UIListLayout" {
+							FillDirection = Enum.FillDirection.Horizontal;
+							HorizontalAlignment = Enum.HorizontalAlignment.Center;
+							HorizontalFlex = Enum.UIFlexAlignment.Fill;
+							Padding = UDim.new(0, INPUT_ROW_PADDING);
+							VerticalAlignment = Enum.VerticalAlignment.Center;
+						};
 
-						[Blend.Instance] = function(textBox)
-							self._hexInput = textBox
-							table.insert(self._tabInputMap, 2, textBox)
-						end;
+						Blend.New "UIPadding" {
+							PaddingBottom = UDim.new(0, INPUT_PADDING);
+							PaddingLeft = UDim.new(0, INPUT_PADDING);
+							PaddingRight = UDim.new(0, INPUT_PADDING);
+							PaddingTop = UDim.new(0, INPUT_PADDING);
+						};
 
-						[Blend.OnChange "Text"] = function(newText)
-							if not self._hexInput then
-								return
-							end
+						Blend.New "ImageLabel" {
+							Name = "icon";
+							BackgroundTransparency = 1;
+							Image = "rbxassetid://6035078895";
+							ImageColor3 = Color3.fromRGB(75, 75, 75);
+							ImageTransparency = transparency;
+							LayoutOrder = 1;
+							Size = UDim2.fromScale(1, 1);
 
-							if newText == self._hexInput.PlaceholderText then
-								return
-							end
+							Blend.New "UIAspectRatioConstraint" {
+								AspectRatio = 1;
+							};
+						};
 
-							if SearchUtils.stringIsHex(self._hexInput.Text) then
-								local _, hex = SearchUtils.stringIsHex(self._hexInput.Text)
-								self:SetColor(Color3.fromHex(hex))
-							end
-						end;
+						Blend.New "TextBox" {
+							Name = "input";
+							BackgroundColor3 = Color3.fromRGB(163, 162, 165);
+							BackgroundTransparency = 1;
+							FontFace = Font.new("rbxasset://fonts/families/RobotoMono.json", Enum.FontWeight.SemiBold, Enum.FontStyle.Normal);
+							LayoutOrder = 1;
+							PlaceholderColor3 = Color3.fromRGB(80, 80, 80);
+							Size = UDim2.fromScale(1, 1);
+							TextColor3 = Color3.fromRGB(255, 255, 255);
+							TextSize = INPUT_TEXT_SIZE;
+							TextTransparency = transparency;
+							TextXAlignment = Enum.TextXAlignment.Left;
+							ZIndex = 5;
 
-						[Blend.OnEvent "Focused"] = function()
-							self:_handleFocused(self._hexInput)
-						end;
+							PlaceholderText = Blend.Computed(targetColor, function(color)
+								return color:ToHex()
+							end);
 
-						[Blend.OnEvent "FocusLost"] = function(enterPressed)
-							if not self._hexInput then
-								return
-							end
+							[Blend.Instance] = function(textBox)
+								self._hexInput = textBox
+								table.insert(self._tabInputMap, 2, textBox)
+							end;
 
-							if enterPressed then
-								if self._hexInput.Text ~= self._hexInput.PlaceholderText then
-									if SearchUtils.stringIsHex(self._hexInput.Text) then
-										local _, hex = SearchUtils.stringIsHex(self._hexInput.Text)
-										self:SetColor(Color3.fromHex(hex))
+							[Blend.OnChange "Text"] = function(newText)
+								if not self._hexInput then
+									return
+								end
+
+								if newText == self._hexInput.PlaceholderText then
+									return
+								end
+
+								if SearchUtils.stringIsHex(self._hexInput.Text) then
+									local _, hex = SearchUtils.stringIsHex(self._hexInput.Text)
+									self:SetColor(Color3.fromHex(hex))
+								end
+							end;
+
+							[Blend.OnEvent "Focused"] = function()
+								self:_handleFocused(self._hexInput)
+							end;
+
+							[Blend.OnEvent "FocusLost"] = function(enterPressed)
+								if not self._hexInput then
+									return
+								end
+
+								if enterPressed then
+									if self._hexInput.Text ~= self._hexInput.PlaceholderText then
+										if SearchUtils.stringIsHex(self._hexInput.Text) then
+											local _, hex = SearchUtils.stringIsHex(self._hexInput.Text)
+											self:SetColor(Color3.fromHex(hex))
+										end
+
+										self._hexInput.Text = ""
+									else
+										self._hexInput.Text = ""
 									end
-
-									self._hexInput.Text = ""
 								else
 									self._hexInput.Text = ""
 								end
-							else
-								self._hexInput.Text = ""
-							end
 
-							self:_handleFocusLost()
-						end;
+								self:_handleFocusLost()
+							end;
+						};
+					};
+
+					Blend.New "Frame" {
+						Name = "opacity";
+						BackgroundColor3 = Color3.fromRGB(15, 15, 15);
+						BackgroundTransparency = transparency;
+						LayoutOrder = 2;
+						Size = UDim2.new(0, OPACITY_WIDTH, 1, 0);
+
+						Blend.New "UIFlexItem" {
+							FlexMode = Enum.UIFlexMode.None;
+						};
+
+						Blend.New "UICorner" {
+							CornerRadius = UDim.new(0, 5);
+						};
+
+						Blend.New "UIStroke" {
+							Color = Color3.fromRGB(40, 40, 40);
+							Transparency = transparency;
+						};
+
+						Blend.New "UIPadding" {
+							PaddingBottom = UDim.new(0, INPUT_PADDING);
+							PaddingLeft = UDim.new(0, INPUT_PADDING);
+							PaddingRight = UDim.new(0, INPUT_PADDING);
+							PaddingTop = UDim.new(0, INPUT_PADDING);
+						};
+
+						Blend.New "TextBox" {
+							Name = "input";
+							BackgroundColor3 = Color3.fromRGB(163, 162, 165);
+							BackgroundTransparency = 1;
+							FontFace = Font.new("rbxasset://fonts/families/RobotoMono.json", Enum.FontWeight.SemiBold, Enum.FontStyle.Normal);
+							PlaceholderColor3 = Color3.fromRGB(80, 80, 80);
+							Size = UDim2.fromScale(1, 1);
+							TextColor3 = Color3.fromRGB(255, 255, 255);
+							TextSize = INPUT_TEXT_SIZE;
+							TextTransparency = transparency;
+							ZIndex = 5;
+
+							PlaceholderText = Blend.Computed(self.CurrentAlpha, function(alpha)
+								return `{math.round(alpha * 100)}%`
+							end);
+
+							[Blend.Instance] = function(textBox)
+								self._opacityInput = textBox
+								table.insert(self._tabInputMap, 3, textBox)
+							end;
+
+							[Blend.OnChange "Text"] = function(newText)
+								if not self._opacityInput or not self._opacityInput:IsFocused() then
+									return
+								end
+
+								if newText == self._opacityInput.PlaceholderText then
+									return
+								end
+
+								local alpha = parseOpacity(newText)
+								if alpha then
+									self:SetAlpha(alpha)
+								end
+							end;
+
+							[Blend.OnEvent "Focused"] = function()
+								self:_handleFocused(self._opacityInput)
+							end;
+
+							[Blend.OnEvent "FocusLost"] = function(enterPressed)
+								if not self._opacityInput then
+									return
+								end
+
+								local text = self._opacityInput.Text
+								if enterPressed and text ~= self._opacityInput.PlaceholderText then
+									local alpha = parseOpacity(text)
+									if alpha then
+										self:SetAlpha(alpha)
+									end
+								end
+
+								self._opacityInput.Text = ""
+								self:_handleFocusLost()
+							end;
+						};
 					};
 				};
 
@@ -1050,7 +1296,7 @@ function ColorPickerPane:Render(props)
 						FillDirection = Enum.FillDirection.Horizontal;
 						HorizontalAlignment = Enum.HorizontalAlignment.Center;
 						HorizontalFlex = Enum.UIFlexAlignment.Fill;
-						Padding = UDim.new(0, 5);
+						Padding = UDim.new(0, INPUT_ROW_PADDING);
 						VerticalAlignment = Enum.VerticalAlignment.Center;
 					};
 
@@ -1071,10 +1317,10 @@ function ColorPickerPane:Render(props)
 						};
 
 						Blend.New "UIPadding" {
-							PaddingBottom = UDim.new(0, 10);
-							PaddingLeft = UDim.new(0, 10);
-							PaddingRight = UDim.new(0, 10);
-							PaddingTop = UDim.new(0, 10);
+							PaddingBottom = UDim.new(0, INPUT_PADDING);
+							PaddingLeft = UDim.new(0, INPUT_PADDING);
+							PaddingRight = UDim.new(0, INPUT_PADDING);
+							PaddingTop = UDim.new(0, INPUT_PADDING);
 						};
 
 						Blend.New "TextBox" {
@@ -1086,7 +1332,7 @@ function ColorPickerPane:Render(props)
 							PlaceholderColor3 = Color3.fromRGB(80, 80, 80);
 							Size = UDim2.fromScale(1, 1);
 							TextColor3 = Color3.fromRGB(255, 255, 255);
-							TextSize = 18;
+							TextSize = INPUT_TEXT_SIZE;
 							TextTransparency = transparency;
 							ZIndex = 5;
 
@@ -1096,7 +1342,7 @@ function ColorPickerPane:Render(props)
 
 							[Blend.Instance] = function(textBox)
 								self._rInput = textBox
-								table.insert(self._tabInputMap, 3, textBox)
+								table.insert(self._tabInputMap, 4, textBox)
 							end;
 
 							[Blend.OnChange "Text"] = function(newText)
@@ -1169,10 +1415,10 @@ function ColorPickerPane:Render(props)
 						};
 
 						Blend.New "UIPadding" {
-							PaddingBottom = UDim.new(0, 10);
-							PaddingLeft = UDim.new(0, 10);
-							PaddingRight = UDim.new(0, 10);
-							PaddingTop = UDim.new(0, 10);
+							PaddingBottom = UDim.new(0, INPUT_PADDING);
+							PaddingLeft = UDim.new(0, INPUT_PADDING);
+							PaddingRight = UDim.new(0, INPUT_PADDING);
+							PaddingTop = UDim.new(0, INPUT_PADDING);
 						};
 
 						Blend.New "TextBox" {
@@ -1184,7 +1430,7 @@ function ColorPickerPane:Render(props)
 							PlaceholderColor3 = Color3.fromRGB(80, 80, 80);
 							Size = UDim2.fromScale(1, 1);
 							TextColor3 = Color3.fromRGB(255, 255, 255);
-							TextSize = 18;
+							TextSize = INPUT_TEXT_SIZE;
 							TextTransparency = transparency;
 							ZIndex = 5;
 
@@ -1194,7 +1440,7 @@ function ColorPickerPane:Render(props)
 
 							[Blend.Instance] = function(textBox)
 								self._gInput = textBox
-								table.insert(self._tabInputMap, 4, textBox)
+								table.insert(self._tabInputMap, 5, textBox)
 							end;
 
 							[Blend.OnChange "Text"] = function(newText)
@@ -1267,10 +1513,10 @@ function ColorPickerPane:Render(props)
 						};
 
 						Blend.New "UIPadding" {
-							PaddingBottom = UDim.new(0, 10);
-							PaddingLeft = UDim.new(0, 10);
-							PaddingRight = UDim.new(0, 10);
-							PaddingTop = UDim.new(0, 10);
+							PaddingBottom = UDim.new(0, INPUT_PADDING);
+							PaddingLeft = UDim.new(0, INPUT_PADDING);
+							PaddingRight = UDim.new(0, INPUT_PADDING);
+							PaddingTop = UDim.new(0, INPUT_PADDING);
 						};
 
 						Blend.New "TextBox" {
@@ -1282,7 +1528,7 @@ function ColorPickerPane:Render(props)
 							PlaceholderColor3 = Color3.fromRGB(80, 80, 80);
 							Size = UDim2.fromScale(1, 1);
 							TextColor3 = Color3.fromRGB(255, 255, 255);
-							TextSize = 18;
+							TextSize = INPUT_TEXT_SIZE;
 							TextTransparency = transparency;
 							ZIndex = 5;
 
@@ -1292,7 +1538,7 @@ function ColorPickerPane:Render(props)
 
 							[Blend.Instance] = function(textBox)
 								self._bInput = textBox
-								table.insert(self._tabInputMap, 5, textBox)
+								table.insert(self._tabInputMap, 6, textBox)
 							end;
 
 							[Blend.OnChange "Text"] = function(newText)


### PR DESCRIPTION
## Summary

- Rework color picker layout and input ordering.
- Add transparency input using 0–1 values and improve alpha handling.
- Support `UIShadow.Color` in color changes.
- Extend visibility toggles to all supported `LayerCollector` types.
- Allow wrapping `UIComponent` selections while skipping nested selections.

## Testing

- Not run